### PR TITLE
Feature/ecct 438 improve docker environment

### DIFF
--- a/.dockerfile
+++ b/.dockerfile
@@ -1,6 +1,0 @@
-*
-!src
-!views
-!package.json
-!package-lock.json
-!tsconfig.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+assets
+dist

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,15 +1,18 @@
+local_resource(
+  name = 'dev:registered-email-address-web',
+  cmd = 'npm --silent install && npm run build',
+  deps = ['src', 'views']
+)
+
 custom_build(
     ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/registered-email-address-web',
     #the following build-command was updated as specified by https://github.com/companieshouse/docker-chs-development/pull/581
     command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF . -f Dockerfile',
     live_update = [
-        sync(local_path = './src', remote_path = '/app/src'),
-        sync(local_path = './views', remote_path = '/app/views'),
-        restart_container()
-      ],
-      deps = [
-        './dist',
-        './src',
-        './views'
-      ]
+      sync(local_path = './dist', remote_path = '/app'),
+      restart_container()
+    ],
+    deps = [
+      './dist'
+    ]
 )

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,18 +1,12 @@
-local_resource(
-  name = 'dev:registered-email-address-web',
-  cmd = 'npm --silent install && npm run build',
-  deps = ['src', 'views']
-)
-
 custom_build(
     ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/registered-email-address-web',
     #the following build-command was updated as specified by https://github.com/companieshouse/docker-chs-development/pull/581
     command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF . -f Dockerfile',
     live_update = [
-      sync(local_path = './dist', remote_path = '/app'),
+      sync(local_path = './src', remote_path = '/app/src'),
       restart_container()
     ],
     deps = [
-      './dist'
+      './src',
     ]
 )

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,7 +1,7 @@
 custom_build(
     ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/registered-email-address-web',
     #the following build-command was updated as specified by https://github.com/companieshouse/docker-chs-development/pull/581
-    command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF . -f Dockerfile',
+    command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF . -f dev.dockerfile',
     live_update = [
       sync(local_path = './src', remote_path = '/app/src'),
       restart_container()

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,5 +1,7 @@
-FROM node:16-alpine
+FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/node-16:alpine-builder
+FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/node-16:alpine-runtime
 
-WORKDIR /app
-
+COPY api-enumerations ./api-enumerations
+RUN cp -r ./dist/* ./ && rm -rf ./dist
+CMD ["--inspect=0.0.0.0:9229", "-L", "server.js"]
 EXPOSE 3000

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -3,5 +3,5 @@ FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/node-16:alpine-runtime
 
 COPY api-enumerations ./api-enumerations
 RUN cp -r ./dist/* ./ && rm -rf ./dist
-CMD ["--inspect=0.0.0.0:9229", "-L", "server.js"]
+CMD ["--inspect=0.0.0.0:9229", "server.js"]
 EXPOSE 3000


### PR DESCRIPTION
Reduced docker build time to about 1 minute by removing unnecessary file transfers using .dockerignorefile
Also uses separate dev.dockerfile when in development mode so includes debug port only when chdev development enabled.