### PR TITLE
Feature/ecct 385 create a service unavailable 503 error screen

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -61,6 +61,7 @@ export const COMPANY_INVALID_PAGE = "invalid";
 export const CHANGE_EMAIL_ADDRESS_PAGE = "change-email-address";
 export const SIGN_OUT_PAGE = `signout`;
 export const ACCESSIBILITY_STATEMENT_PAGE = "accessibility-statement";
+export const SERVICE_UNAVAILABLE_PAGE = "service-unavailable";
 
 
 // ROUTING PATHS
@@ -88,3 +89,4 @@ export const EMAIL_CHANGE_EMAIL_ADDRESS_URL = `${HOME_URL}/${EMAIL_CHANGE_EMAIL_
 export const EMAIL_CHECK_ANSWER_URL = `${HOME_URL}/${EMAIL_CHECK_ANSWER}`;
 export const ACCESSIBILITY_STATEMENT_URL = `${HOME_URL}/${ACCESSIBILITY_STATEMENT_PAGE}`;
 export const EMAIL_UPDATE_SUBMITTED_URL = `${HOME_URL}/${EMAIL_UPDATE_SUBMITTED}`;
+export const SERVICE_UNAVAILABLE_URL = `${HOME_URL}/${SERVICE_UNAVAILABLE_PAGE}`;

--- a/src/constants/app.const.ts
+++ b/src/constants/app.const.ts
@@ -7,13 +7,13 @@ export const PAGE_TITLE_SUFFIX = `${config.APPLICATION_NAME} - GOV.UK`;
 export const BANNER_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/closing-a-company-feedback";
 export const CONFIRMATION_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/closing-a-company-confirmation";
 export const COMPANY_PROFILE = "companyProfile";
-export const COMPANY_EMAIL = "companyEmail";
 export const COMPANY_NUMBER = "companyNumber";
 export const USER_EMAIL = "userEmail";
 
 export const SUBMISSION_ID = "submissionID";
 export const INVALID_COMPANY_NUMBER = "You must enter a valid company number";
 export const SERVICE_UNAVAILABLE = "Service unavailable";
+export const SOMETHING_HAS_GONE_WRONG = "Something has gone wrong";
 export const NO_EMAIL_ADDRESS_FOUND = "No email address for company number";
 export const EMAIL_ADDRESS_INVALID = "Enter an email address in the correct format, like name@example.com";
 export const NO_EMAIL_ADDRESS_SUPPLIED = "Enter the registered email address";

--- a/src/constants/app.const.ts
+++ b/src/constants/app.const.ts
@@ -13,6 +13,7 @@ export const USER_EMAIL = "userEmail";
 
 export const SUBMISSION_ID = "submissionID";
 export const INVALID_COMPANY_NUMBER = "You must enter a valid company number";
+export const SERVICE_UNAVAILABLE = "Service unavailable";
 export const NO_EMAIL_ADDRESS_FOUND = "No email address for company number";
 export const EMAIL_ADDRESS_INVALID = "Enter an email address in the correct format, like name@example.com";
 export const NO_EMAIL_ADDRESS_SUPPLIED = "Enter the registered email address";

--- a/src/constants/validation.const.ts
+++ b/src/constants/validation.const.ts
@@ -5,8 +5,9 @@ import * as config from "../config/index";
 export const VALID_COMPANY_TYPES = ["private-unlimited", "ltd", "plc", "private-limited-guarant-nsc-limited-exemption", "private-limited-guarant-nsc", "private-unlimited-nsc", "private-limited-shares-section-30-exemption"];
 export const VALID_COMPANY_STATUS = ["active", "liquidation", "receivership", "voluntary-agreement", "insolvency-proceedings", "administration"];
 export const INVALID_COMPANY_TYPE_REASON = "invalidCompanyType";
-export const INVALID_COMPANY_STATUS_REASON= "invalidCompanyStatus";
-export const INVALID_COMPANY_NO_EMAIL_REASON= "invalidCompanyNoEmail";
+export const INVALID_COMPANY_STATUS_REASON = "invalidCompanyStatus";
+export const INVALID_COMPANY_NO_EMAIL_REASON = "invalidCompanyNoEmail";
+export const INVALID_COMPANY_SERVICE_UNAVAILABLE = "invalidCompanyServiceUnavailable";
 
 export const COMPANY_NAME_PLACEHOLDER = "COMPANY_NAME_PLACEHOLDER";
 

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -6,14 +6,9 @@ console.log(`env.LOG_LEVEL set to ${process.env.LOG_LEVEL}`);
 
 export const logger: ApplicationLogger = createLogger(process.env.APP_NAME ?? "registered-email-address-web");
 
-export const createAndLogError = (description: string): Error => {
+export const createAndLogError = (name: string, description: string): Error => {
   const error = new Error(description);
-  logger.error(`${error.stack}`);
-  return error;
-};
-
-export const createAndLogServiceUnavailable = (description: string): Error => {
-  const error = new Error(description + " - Service Unavailable");
+  error.name = name;
   logger.error(`${error.stack}`);
   return error;
 };

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -12,3 +12,9 @@ export const createAndLogError = (description: string): Error => {
   return error;
 };
 
+export const createAndLogServiceUnavailable = (description: string): Error => {
+  const error = new Error(description + " - Service Unavailable");
+  logger.error(`${error.stack}`);
+  return error;
+};
+

--- a/src/routers/companyRouter.ts
+++ b/src/routers/companyRouter.ts
@@ -8,6 +8,7 @@ import { logger } from "../lib/Logger";
 import FormValidator from "../utils/formValidator.util";
 import CompanyNumberSanitizer from "../utils/companyNumberSanitizer";
 import * as constants from "../constants/app.const";
+import * as validationConstants from "../constants/validation.const";
 
 const router: Router = Router();
 const routeViews: string = "router_views/company/";
@@ -53,8 +54,12 @@ router.post(config.CONFIRM_URL, async (req: Request, res: Response, next: NextFu
   const handler = new ConfirmCompanyHandler();
   await handler.post(req, res).then((data) => {
     if (Object.prototype.hasOwnProperty.call(data, invalidCompanyReason)) {
-      req.session?.setExtraData(constants.INVALID_COMPANY_REASON, data.invalidCompanyReason);
-      res.redirect(config.INVALID_COMPANY_URL);
+      if (data.invalidCompanyReason === validationConstants.INVALID_COMPANY_SERVICE_UNAVAILABLE) {
+        res.redirect(config.SERVICE_UNAVAILABLE_URL);
+      } else {
+        req.session?.setExtraData(constants.INVALID_COMPANY_REASON, data.invalidCompanyReason);
+        res.redirect(config.INVALID_COMPANY_URL);
+      }
     } else {
       res.redirect(config.EMAIL_CHANGE_EMAIL_ADDRESS_URL);
     }

--- a/src/routers/emailRouter.ts
+++ b/src/routers/emailRouter.ts
@@ -7,7 +7,8 @@ import FormValidator from "../utils/formValidator.util";
 import * as constants from "../constants/app.const";
 
 const router: Router = Router();
-const routeViews: string = "router_views/email/";
+const companyRouterViews: string = "router_views/company/";
+const emailRouterViews: string = "router_views/email/";
 const errorsConst: string = "errors";
 
 // GET: /change-email-address
@@ -19,9 +20,10 @@ router.get(config.CHANGE_EMAIL_ADDRESS_URL, async (req: Request, res: Response, 
   );
   await handler.get(req, res).then((viewData) => {
     if (Object.prototype.hasOwnProperty.call(viewData, errorsConst) === true) {
-      res.render(`${routeViews}` + config.COMPANY_SEARCH_PAGE, viewData);
+      // TODO: go to "something has gone" wrong page
+      res.render(`${companyRouterViews}` + config.COMPANY_SEARCH_PAGE, viewData);
     } else {
-      res.render(`router_views/email/${config.CHANGE_EMAIL_ADDRESS_URL}`, viewData);
+      res.render(`${emailRouterViews}` + config.CHANGE_EMAIL_ADDRESS_URL, viewData);
     }
   });
 });
@@ -35,9 +37,9 @@ router.post(config.CHANGE_EMAIL_ADDRESS_URL, async (req: Request, res: Response,
   );
   await handler.post(req, res).then((viewData) => {
     if (Object.prototype.hasOwnProperty.call(viewData, errorsConst) === true) {
-      res.render(`${routeViews}` + config.CHANGE_EMAIL_ADDRESS_URL, viewData);
+      res.render(`${emailRouterViews}` + config.CHANGE_EMAIL_ADDRESS_URL, viewData);
     } else {
-      req.session?.setExtraData(constants.COMPANY_EMAIL, req.body.changeEmailAddress);
+      req.session?.setExtraData(constants.REGISTERED_EMAIL_ADDRESS, req.body.changeEmailAddress);
       res.redirect(config.EMAIL_CHECK_ANSWER_URL);
     }
   });
@@ -48,8 +50,14 @@ router.get(config.CHECK_ANSWER_URL, async (req: Request, res: Response, next: Ne
   const handler = new ConfirmChangeEmailAddressHandler(
     req.session?.data.signin_info?.user_profile?.email
   );
-  const viewData = await handler.get(req, res);
-  res.render(`${routeViews}` + config.CHECK_ANSWER_URL, viewData);
+  await handler.get(req, res).then((viewData) => {
+    if (Object.prototype.hasOwnProperty.call(viewData, errorsConst) === true) {
+      // TODO: go to "something has gone" wrong page
+      res.render(`${companyRouterViews}` + config.COMPANY_SEARCH_PAGE, viewData);
+    } else {
+      res.render(`${emailRouterViews}` + config.CHECK_ANSWER_URL, viewData);
+    }
+  });
 });
 
 // GET: /update-submitted

--- a/src/routers/emailRouter.ts
+++ b/src/routers/emailRouter.ts
@@ -64,7 +64,7 @@ router.get(config.CHECK_ANSWER_URL, async (req: Request, res: Response, next: Ne
 router.get(config.UPDATE_SUBMITTED, async (req: Request, res: Response, next: NextFunction) => {
   const handler = new UpdateSubmittedHandler();
   await handler.get(req, res).then((viewData) => {
-    res.render(`${routeViews}` + config.UPDATE_SUBMITTED, viewData);
+    res.render(`${emailRouterViews}` + config.UPDATE_SUBMITTED, viewData);
   });
 });
 

--- a/src/routers/emailRouter.ts
+++ b/src/routers/emailRouter.ts
@@ -18,7 +18,11 @@ router.get(config.CHANGE_EMAIL_ADDRESS_URL, async (req: Request, res: Response, 
     req.session?.data.signin_info?.user_profile?.email  
   );
   await handler.get(req, res).then((viewData) => {
-    res.render(`router_views/email/${config.CHANGE_EMAIL_ADDRESS_URL}`, viewData);
+    if (Object.prototype.hasOwnProperty.call(viewData, errorsConst) === true) {
+      res.render(`${routeViews}` + config.COMPANY_SEARCH_PAGE, viewData);
+    } else {
+      res.render(`router_views/email/${config.CHANGE_EMAIL_ADDRESS_URL}`, viewData);
+    }
   });
 });
 

--- a/src/routers/handlers/company/companySearch.ts
+++ b/src/routers/handlers/company/companySearch.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { GenericHandler } from "../generic";
 import { inject } from "inversify";
-import { logger, createAndLogServiceUnavailable } from "../../../lib/Logger";
+import { logger } from "../../../lib/Logger";
 import { REA_HOME_PAGE } from "../../../config/index";
 import Optional from "../../../models/optional";
 import FormValidator from "../../../utils/formValidator.util";
@@ -38,7 +38,8 @@ export class CompanySearchHandlerPost extends GenericHandler {
       const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
       return companyProfile;
     } catch (e: any) {
-      if (e instanceof createAndLogServiceUnavailable) {
+      const error = e as Error;
+      if (error?.name === SERVICE_UNAVAILABLE) {
         logger.info(`company confirm - oracle query service unavailable`);
         this.viewData.errors = {
           companyNumber: SERVICE_UNAVAILABLE

--- a/src/routers/handlers/company/confirm.ts
+++ b/src/routers/handlers/company/confirm.ts
@@ -5,7 +5,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { getCompanyProfile } from "../../../services/company/company.profile.service";
 import { buildAddress, formatForDisplay } from "../../../services/company/confirm.company.service";
 import { getCompanyEmail } from "../../../services/company/company.email.service";
-import { logger, createAndLogServiceUnavailable } from "../../../lib/Logger";
+import { logger } from "../../../lib/Logger";
 import * as constants from "../../../constants/app.const";
 import * as validationConstants from "../../../constants/validation.const";
 import * as config from "../../../config/index";
@@ -32,7 +32,8 @@ export class ConfirmCompanyHandler extends GenericHandler {
         session?.setExtraData(constants.COMPANY_PROFILE, companyProfile);
         this.buildPageOptions(session, companyProfile);
       } catch (e) {
-        if (e instanceof createAndLogServiceUnavailable) {
+        const error = e as Error;
+        if (error?.name === constants.SERVICE_UNAVAILABLE) {
           logger.info(`company confirm - oracle query service unavailable`);
           this.viewData.errors = {
             companyNumber: constants.SERVICE_UNAVAILABLE
@@ -63,9 +64,10 @@ export class ConfirmCompanyHandler extends GenericHandler {
         logger.info(`company confirm - checking company email`);
         const companyEmail = await getCompanyEmail(companyProfile.companyNumber);
         logger.info(`company confirm - company email found: ${companyEmail}`);
-        session?.setExtraData(constants.REGISTERED_EMAIL_ADDRESS, companyEmail);
-      } catch (e: any) {
-        if (e instanceof createAndLogServiceUnavailable) {
+        session?.setExtraData(constants.REGISTERED_EMAIL_ADDRESS, companyEmail.registeredEmailAddress);
+      } catch (e) {
+        const error = e as Error;
+        if (error?.name === constants.SERVICE_UNAVAILABLE) {
           logger.info(`company confirm - oracle query service unavailable`);
           this.viewData.invalidCompanyReason = validationConstants.INVALID_COMPANY_SERVICE_UNAVAILABLE;
         } else {

--- a/src/routers/handlers/email/changeEmailAddress.ts
+++ b/src/routers/handlers/email/changeEmailAddress.ts
@@ -6,9 +6,8 @@ import { logger } from "../../../lib/Logger";
 import { validateEmailString } from "../../../utils/validateEmailString";
 
 import { 
-  COMPANY_EMAIL,
-  COMPANY_NUMBER,
   NO_EMAIL_ADDRESS_FOUND,
+  REGISTERED_EMAIL_ADDRESS,
   EMAIL_ADDRESS_INVALID
 } from "../../../constants/app.const";
 
@@ -19,6 +18,7 @@ import ValidationErrors from "../../../models/view/validationErrors.model";
 import Optional from "../../../models/optional";
 import FormValidator from "../../../utils/formValidator.util";
 import formSchema from "../../../schemas/changeEmailAddress.schema";
+import { RegisteredEmailAddress } from "services/api/private-get-rea";
 
 export class ChangeEmailAddressHandler extends GenericHandler {
 
@@ -34,7 +34,7 @@ export class ChangeEmailAddressHandler extends GenericHandler {
   async get (req: Request, response: Response): Promise<Object> {
     logger.info(`GET request to serve change registered email address page`);
 
-    const companyEmailAddress: string | undefined = req.session?.getExtraData(COMPANY_EMAIL);
+    const companyEmailAddress: RegisteredEmailAddress | undefined = req.session?.getExtraData(REGISTERED_EMAIL_ADDRESS);
 
     if (companyEmailAddress !== undefined) {
       this.viewData.companyEmailAddress = companyEmailAddress;

--- a/src/routers/handlers/email/changeEmailAddress.ts
+++ b/src/routers/handlers/email/changeEmailAddress.ts
@@ -2,30 +2,20 @@ import { Request, Response } from "express";
 import { GenericHandler } from "../generic";
 import { inject } from "inversify";
 import { Session } from "@companieshouse/node-session-handler";
-import { logger, createAndLogError } from "../../../lib/Logger";
+import { logger } from "../../../lib/Logger";
 import { validateEmailString } from "../../../utils/validateEmailString";
-import { getCompanyEmail } from "../../../services/company/company.email.service";
-import { postTransaction } from "../../../services/transaction/transaction.service";
 
 import { 
   COMPANY_EMAIL,
   COMPANY_NUMBER,
-  SUBMISSION_ID,
   NO_EMAIL_ADDRESS_FOUND,
-  EMAIL_ADDRESS_INVALID,
-  TRANSACTION_CREATE_ERROR 
+  EMAIL_ADDRESS_INVALID
 } from "../../../constants/app.const";
 
-import { 
-  COMPANY_BASE_URL,
-  CONFIRM_URL,
-  DESCRIPTION,
-  REFERENCE 
-} from "../../../config/index";
+import { COMPANY_BASE_URL, CONFIRM_URL } from "../../../config/index";
 
 import ValidationErrors from "../../../models/view/validationErrors.model";
 
-import { StatusCodes } from 'http-status-codes';
 import Optional from "../../../models/optional";
 import FormValidator from "../../../utils/formValidator.util";
 import formSchema from "../../../schemas/changeEmailAddress.schema";
@@ -44,39 +34,14 @@ export class ChangeEmailAddressHandler extends GenericHandler {
   async get (req: Request, response: Response): Promise<Object> {
     logger.info(`GET request to serve change registered email address page`);
 
-    const session: Session = req.session as Session;
-    const companyNumber: string | undefined = req.session?.getExtraData(COMPANY_NUMBER);
     const companyEmailAddress: string | undefined = req.session?.getExtraData(COMPANY_EMAIL);
 
-    // check session state - if not found, we'll need a call to oracle api
     if (companyEmailAddress !== undefined) {
       this.viewData.companyEmailAddress = companyEmailAddress;
       return Promise.resolve(this.viewData); 
     } else {
-      if (companyNumber !== undefined) {
-        // create transaction record
-        try {
-          // get transaction record data
-          await createTransaction(session, companyNumber).then((transactionId) => {
-            req.session?.setExtraData(SUBMISSION_ID, transactionId);
-          });
-        } catch (e) {
-          this.viewData.errors = {
-            companyNumber: TRANSACTION_CREATE_ERROR+companyNumber
-          };
-          return this.viewData;
-        }
-        await getCompanyEmail(companyNumber).then((companyEmail) => {
-          if (companyEmail.resource?.companyEmail === undefined) {
-            this.viewData.errors = {
-              changeEmailAddress: NO_EMAIL_ADDRESS_FOUND
-            };
-            return Promise.resolve(this.viewData);
-          } else {
-            this.viewData.companyEmailAddress = companyEmail.resource?.companyEmail;
-          }
-        });
-      }
+      logger.info(`company confirm - company email not found`);
+      this.viewData.errors = NO_EMAIL_ADDRESS_FOUND;
     }
     return Promise.resolve(this.viewData);
   }
@@ -104,16 +69,3 @@ export class ChangeEmailAddressHandler extends GenericHandler {
     return Promise.resolve(this.viewData);
   }
 }
-
-// create transaction record
-export const createTransaction = async (session: Session, companyNumber: string): Promise<string> => {
-  let transactionId: string = "";
-  try {
-    await postTransaction(session, companyNumber, DESCRIPTION, REFERENCE).then((transaction) => {
-      transactionId = transaction.id as string;
-    });
-    return Promise.resolve(transactionId);
-  } catch (e) {
-    throw createAndLogError(`update registered email address: ${StatusCodes.INTERNAL_SERVER_ERROR} - error while create transaction record for ${companyNumber}`);
-  }
-};

--- a/src/routers/handlers/email/confirmEmailChange.ts
+++ b/src/routers/handlers/email/confirmEmailChange.ts
@@ -1,9 +1,7 @@
 import { Request, Response } from "express";
 import { GenericHandler } from "../generic";
 import { logger } from "../../../lib/Logger";
-import { validateEmailString } from "../../../utils/validateEmailString";
-import { getCompanyEmail } from "../../../services/company/company.email.service";
-import { COMPANY_EMAIL, NO_EMAIL_ADDRESS_FOUND } from "../../../constants/app.const";
+import { REGISTERED_EMAIL_ADDRESS, NO_EMAIL_ADDRESS_FOUND } from "../../../constants/app.const";
 import { EMAIL_CHANGE_EMAIL_ADDRESS_URL } from "../../../config/index";
 
 export class ConfirmChangeEmailAddressHandler extends GenericHandler {
@@ -19,12 +17,11 @@ export class ConfirmChangeEmailAddressHandler extends GenericHandler {
   
   async get (req: Request, response: Response): Promise<Object> {
     logger.info(`GET request to serve confirm change registered email address page`);
-    let companyNumber: string | undefined;
-    // first try session for companyNumber, else query param
-    if (req.session?.getExtraData(COMPANY_EMAIL) !== undefined) {
-      this.viewData.companyEmailAddress = req.session?.getExtraData(COMPANY_EMAIL);
+
+    if (req.session?.getExtraData(REGISTERED_EMAIL_ADDRESS) !== undefined) {
+      this.viewData.companyEmailAddress = req.session?.getExtraData(REGISTERED_EMAIL_ADDRESS);
       // reset email in session - don't want this in reality
-      req.session?.setExtraData(COMPANY_EMAIL, undefined);
+      req.session?.setExtraData(REGISTERED_EMAIL_ADDRESS, undefined);
       return Promise.resolve(this.viewData);
     } else{
       this.viewData.errors = {

--- a/src/routers/indexRouter.ts
+++ b/src/routers/indexRouter.ts
@@ -44,4 +44,8 @@ router.get(config.ACCESSIBILITY_STATEMENT_URL, async (req: Request, res: Respons
   res.render(`${routeViews}` + config.ACCESSIBILITY_STATEMENT_PAGE);
 });
 
+router.get(config.SERVICE_UNAVAILABLE_URL, async (req: Request, res: Response, next: NextFunction) => {
+  res.render(`${routeViews}` + config.SERVICE_UNAVAILABLE_PAGE, { title: "Service offline - " + config.REFERENCE + " - GOV.UK" });
+});
+
 export default router;

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -6,14 +6,14 @@ import { API_URL, CHS_API_KEY } from "../../config/index";
 import { createAndLogError } from "../../lib/Logger";
 import { createApiClient } from "@companieshouse/api-sdk-node";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
-import { getAccessToken } from "../../utils/session";
+import { SOMETHING_HAS_GONE_WRONG } from "../../constants/app.const";
 
 export const createPublicOAuthApiClient = (session: Session): ApiClient => {
   const oAuth = session.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken];
   if (oAuth) {
     return createApiClient(undefined, oAuth, API_URL);
   }
-  throw createAndLogError("Error getting session keys for creating public api client");
+  throw createAndLogError( SOMETHING_HAS_GONE_WRONG, "Error getting session keys for creating public api client");
 };
 
 export const createPublicApiKeyClient = (): ApiClient => {
@@ -25,5 +25,5 @@ export const createPaymentApiClient = (session: Session, paymentUrl: string): Ap
   if (oAuth) {
     return createApiClient(undefined, oAuth, paymentUrl);
   }
-  throw createAndLogError("Error getting session keys for creating public api client");
+  throw createAndLogError( SOMETHING_HAS_GONE_WRONG, "Error getting session keys for creating public api client");
 };

--- a/src/services/api/private-get-rea/config.ts
+++ b/src/services/api/private-get-rea/config.ts
@@ -1,0 +1,2 @@
+export const API_URL = process.env.API_URL || "https://api.companieshouse.gov.uk";
+export const ACCOUNT_URL = process.env.ACCOUNT_URL || "https://account.companieshouse.gov.uk";

--- a/src/services/api/private-get-rea/index.ts
+++ b/src/services/api/private-get-rea/index.ts
@@ -1,0 +1,42 @@
+import PrivateApiClient from "./privateApiClient";
+import { API_URL, ACCOUNT_URL } from "./config";
+import { RequestClient, HttpClientOptions, IHttpClient } from "@companieshouse/api-sdk-node/dist/http";
+import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
+
+/**
+ * Creates a new API Client.
+ *
+ * @param apiKey the api key to use for authentication
+ * @param oauthToken a user's oauth token that can be used for authentication
+ * @param baseUrl the api base url
+ */
+export const createPrivateApiClient = (apiKey?: string, oauthToken?: string, baseUrl: string = API_URL, baseAccountUrl: string = ACCOUNT_URL): PrivateApiClient => {
+  if (apiKey && oauthToken) {
+    throw new Error("You cannot set both api key and oauth token to create a client. Please use one or the other");
+  }
+
+  // the http client adapter for the api domain
+  const apiOptions: HttpClientOptions = {
+    apiKey,
+    baseUrl,
+    oauthToken
+  };
+  const apiHttpClient = new RequestClient(apiOptions);
+
+  // the http client adapter for the account domain
+  const accountOptions: HttpClientOptions = {
+    apiKey: apiKey,
+    baseUrl: baseAccountUrl,
+    oauthToken: oauthToken
+  };
+  const accountHttpClient = new RequestClient(accountOptions);
+
+  // the api client
+  return new PrivateApiClient(apiHttpClient, accountHttpClient);
+};
+
+// exports used by private sdk to provide private services without the need to duplicate configs or http client logic
+export { IHttpClient, HttpClientOptions, RequestClient, API_URL, ACCOUNT_URL, Resource };
+
+export * from "./types";
+export * from "./service";

--- a/src/services/api/private-get-rea/privateApiClient.ts
+++ b/src/services/api/private-get-rea/privateApiClient.ts
@@ -1,0 +1,14 @@
+import { IHttpClient } from "@companieshouse/api-sdk-node/dist/http";
+import RegisteredEmailAddressService from "./service";
+
+/**
+ * ApiClient is the class that all service objects hang off.
+ */
+export default class PrivateApiClient {
+  public readonly registeredEmailAddress: RegisteredEmailAddressService;
+
+  constructor (readonly apiClient: IHttpClient, readonly accountClient: IHttpClient) {
+    // services on the api domain using the apiClient
+    this.registeredEmailAddress = new RegisteredEmailAddressService(apiClient);
+  }
+}

--- a/src/services/api/private-get-rea/service.ts
+++ b/src/services/api/private-get-rea/service.ts
@@ -1,0 +1,45 @@
+import { IHttpClient } from "@companieshouse/api-sdk-node/dist/http";
+import { RegisteredEmailAddress, RegisteredEmailAddressResource} from "./types";
+import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
+import { createPrivateApiClient } from "./index";
+import { CHS_API_KEY, ORACLE_QUERY_API_URL } from "../../../config";
+
+/**
+ * https://developer.companieshouse.gov.uk/api/docs/company/company_number/company_number.html
+ */
+export default class RegisteredEmailAddressService {
+  constructor (private readonly client: IHttpClient) { }
+
+  /**
+    * Get the profile for a company.
+    *
+    * @param number the company number to look up
+    */
+  public async getRegisteredEmailAddress (number: string): Promise<Resource<RegisteredEmailAddress>> {
+    // build client object
+    const client = createPrivateApiClient(
+      CHS_API_KEY,
+      undefined,
+      ORACLE_QUERY_API_URL
+    );
+
+    const resp = await this.client.httpGet(`/company/${number}/registered-email-address`);
+
+    const resource: Resource<RegisteredEmailAddress> = {
+      httpStatusCode: resp.status
+    };
+
+    if (resp.error) {
+      return resource;
+    }
+
+    // cast the response body to the expected type
+    const body = resp.body as RegisteredEmailAddressResource;
+
+    resource.resource = {
+      registeredEmailAddress: body.registered_email_address
+    };
+
+    return resource;
+  }
+}

--- a/src/services/api/private-get-rea/types.ts
+++ b/src/services/api/private-get-rea/types.ts
@@ -1,0 +1,11 @@
+/**
+ * RegisteredEmailAddressResource is what is returned from the api.
+ */
+export interface RegisteredEmailAddressResource {
+  registered_email_address: string;
+}
+
+// response resource
+export interface RegisteredEmailAddress {
+  registeredEmailAddress: string;
+}

--- a/src/services/company/company.email.service.ts
+++ b/src/services/company/company.email.service.ts
@@ -1,7 +1,8 @@
 import { Resource } from "@companieshouse/api-sdk-node";
 import { createPrivateApiClient, RegisteredEmailAddress } from "../api/private-get-rea";
 import { CHS_API_KEY, ORACLE_QUERY_API_URL } from "../../config";
-import { logger, createAndLogError, createAndLogServiceUnavailable } from "../../lib/Logger";
+import { logger, createAndLogError } from "../../lib/Logger";
+import { SOMETHING_HAS_GONE_WRONG, SERVICE_UNAVAILABLE } from "../../constants/app.const";
 import { StatusCodes } from 'http-status-codes';
 
 /**
@@ -16,17 +17,17 @@ export const getCompanyEmail = async (companyNumber: string): Promise<Registered
   const sdkResponse: Resource<RegisteredEmailAddress> = await privateApiClient.registeredEmailAddress.getRegisteredEmailAddress(companyNumber);
 
   if (!sdkResponse) {
-    throw createAndLogServiceUnavailable(`Registered email address API for company number ${companyNumber}`);
+    throw createAndLogError( SERVICE_UNAVAILABLE, `Registered email address API for company number ${companyNumber}`);
   }
 
-  if (sdkResponse.httpStatusCode === StatusCodes.SERVICE_UNAVAILABLE) {
-    throw createAndLogServiceUnavailable(`Registered email address API for company number ${companyNumber}`);
+  if (sdkResponse.httpStatusCode === StatusCodes.SERVICE_UNAVAILABLE || sdkResponse.httpStatusCode === StatusCodes.INTERNAL_SERVER_ERROR) {
+    throw createAndLogError( SERVICE_UNAVAILABLE, `Registered email address API for company number ${companyNumber}`);
   } else if (sdkResponse.httpStatusCode >= StatusCodes.BAD_REQUEST) {
-    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to get registered email address for company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Http status code ${sdkResponse.httpStatusCode} - Failed to get registered email address for company number ${companyNumber}`);
   }
 
   if (!sdkResponse.resource) {
-    throw createAndLogError(`Registered email address API returned no resource for company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Registered email address API returned no resource for company number ${companyNumber}`);
   }
 
   logger.debug(`Received registered email address ${JSON.stringify(sdkResponse)}`);

--- a/src/services/company/company.email.service.ts
+++ b/src/services/company/company.email.service.ts
@@ -1,36 +1,35 @@
-import { companyEmailResource, companyEmail } from "./resources/resources";
-import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
-import { CHS_API_KEY, ORACLE_QUERY_API_URL } from "../../config/index";
+import { Resource } from "@companieshouse/api-sdk-node";
+import { createPrivateApiClient, RegisteredEmailAddress } from "../api/private-get-rea";
+import { CHS_API_KEY, ORACLE_QUERY_API_URL } from "../../config";
+import { logger, createAndLogError, createAndLogServiceUnavailable } from "../../lib/Logger";
 import { StatusCodes } from 'http-status-codes';
 
 /**
-* Get the registered email address for a company.
+* Get the registered email address for a company - private API
 *
 * @param companyNumber the company number to look up
 */
-export const getCompanyEmail = async (companyNumber: string): Promise<Resource<companyEmail>> => {
-  // build client object
-  const client = createApiClient(
-    CHS_API_KEY,
-    undefined,
-    ORACLE_QUERY_API_URL
-  );
-  const resp = await client.apiClient.httpGet(`/company/${companyNumber}/registered-email-address`);
+export const getCompanyEmail = async (companyNumber: string): Promise<RegisteredEmailAddress> => {
+  const privateApiClient = createPrivateApiClient(CHS_API_KEY, undefined, ORACLE_QUERY_API_URL );
 
-  const emailResource: Resource<companyEmail> = {
-    httpStatusCode: resp.status
-  };
+  logger.debug(`Looking for registered email address with company number ${companyNumber}`);
+  const sdkResponse: Resource<RegisteredEmailAddress> = await privateApiClient.registeredEmailAddress.getRegisteredEmailAddress(companyNumber);
 
-  // return error response code if one received
-  if (resp.status >= StatusCodes.BAD_REQUEST) {
-    return emailResource;
+  if (!sdkResponse) {
+    throw createAndLogServiceUnavailable(`Registered email address API for company number ${companyNumber}`);
   }
 
-  // cast response body to expected companyEmailResource type
-  const body = resp.body as companyEmailResource;
+  if (sdkResponse.httpStatusCode === StatusCodes.SERVICE_UNAVAILABLE) {
+    throw createAndLogServiceUnavailable(`Registered email address API for company number ${companyNumber}`);
+  } else if (sdkResponse.httpStatusCode >= StatusCodes.BAD_REQUEST) {
+    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to get registered email address for company number ${companyNumber}`);
+  }
 
-  emailResource.resource = {
-    companyEmail: body.registered_email_address
-  };
-  return emailResource;
+  if (!sdkResponse.resource) {
+    throw createAndLogError(`Registered email address API returned no resource for company number ${companyNumber}`);
+  }
+
+  logger.debug(`Received registered email address ${JSON.stringify(sdkResponse)}`);
+
+  return sdkResponse.resource;
 };

--- a/src/services/company/company.profile.service.ts
+++ b/src/services/company/company.profile.service.ts
@@ -1,8 +1,14 @@
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { CHS_API_KEY } from "../../config/index";
-import { logger, createAndLogError } from "../../lib/Logger";
+import { logger, createAndLogError, createAndLogServiceUnavailable } from "../../lib/Logger";
+import { StatusCodes } from 'http-status-codes';
 
+/**
+* Get the profile for a company.
+*
+* @param companyNumber the company number to look up
+*/
 export const getCompanyProfile = async (companyNumber: string): Promise<CompanyProfile> => {
   const apiClient = createApiClient(CHS_API_KEY);
 
@@ -10,15 +16,17 @@ export const getCompanyProfile = async (companyNumber: string): Promise<CompanyP
   const sdkResponse: Resource<CompanyProfile> = await apiClient.companyProfile.getCompanyProfile(companyNumber);
 
   if (!sdkResponse) {
-    throw createAndLogError(`Company Profile API returned no response for company number ${companyNumber}`);
+    throw createAndLogServiceUnavailable(`Company profile API for company number ${companyNumber}`);
   }
 
-  if (sdkResponse.httpStatusCode >= 400) {
+  if (sdkResponse.httpStatusCode === StatusCodes.SERVICE_UNAVAILABLE) {
+    throw createAndLogServiceUnavailable(`Company profile API for company number ${companyNumber}`);
+  } else if (sdkResponse.httpStatusCode >= StatusCodes.BAD_REQUEST) {
     throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to get company profile for company number ${companyNumber}`);
   }
 
   if (!sdkResponse.resource) {
-    throw createAndLogError(`Company Profile API returned no resource for company number ${companyNumber}`);
+    throw createAndLogError(`Company profile API returned no resource for company number ${companyNumber}`);
   }
 
   logger.debug(`Received company profile ${JSON.stringify(sdkResponse)}`);

--- a/src/services/company/company.profile.service.ts
+++ b/src/services/company/company.profile.service.ts
@@ -1,7 +1,8 @@
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { CHS_API_KEY } from "../../config/index";
-import { logger, createAndLogError, createAndLogServiceUnavailable } from "../../lib/Logger";
+import { logger, createAndLogError } from "../../lib/Logger";
+import { SOMETHING_HAS_GONE_WRONG, SERVICE_UNAVAILABLE } from "../../constants/app.const";
 import { StatusCodes } from 'http-status-codes';
 
 /**
@@ -16,17 +17,17 @@ export const getCompanyProfile = async (companyNumber: string): Promise<CompanyP
   const sdkResponse: Resource<CompanyProfile> = await apiClient.companyProfile.getCompanyProfile(companyNumber);
 
   if (!sdkResponse) {
-    throw createAndLogServiceUnavailable(`Company profile API for company number ${companyNumber}`);
+    throw createAndLogError( SERVICE_UNAVAILABLE, `Company profile API for company number ${companyNumber}`);
   }
 
-  if (sdkResponse.httpStatusCode === StatusCodes.SERVICE_UNAVAILABLE) {
-    throw createAndLogServiceUnavailable(`Company profile API for company number ${companyNumber}`);
+  if (sdkResponse.httpStatusCode === StatusCodes.SERVICE_UNAVAILABLE || sdkResponse.httpStatusCode === StatusCodes.INTERNAL_SERVER_ERROR) {
+    throw createAndLogError( SERVICE_UNAVAILABLE, `Company profile API for company number ${companyNumber}`);
   } else if (sdkResponse.httpStatusCode >= StatusCodes.BAD_REQUEST) {
-    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to get company profile for company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Http status code ${sdkResponse.httpStatusCode} - Failed to get company profile for company number ${companyNumber}`);
   }
 
   if (!sdkResponse.resource) {
-    throw createAndLogError(`Company profile API returned no resource for company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Company profile API returned no resource for company number ${companyNumber}`);
   }
 
   logger.debug(`Received company profile ${JSON.stringify(sdkResponse)}`);

--- a/src/services/company/resources/resources.ts
+++ b/src/services/company/resources/resources.ts
@@ -1,9 +1,0 @@
-// raw interface resource
-export interface companyEmailResource {
-    registered_email_address: string;
-}
-
-// response resource
-export interface companyEmail {
-    companyEmail: string;
-}

--- a/src/services/transaction/transaction.service.ts
+++ b/src/services/transaction/transaction.service.ts
@@ -1,6 +1,7 @@
 import { Resource } from "@companieshouse/api-sdk-node";
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { createAndLogError, logger } from "../../lib/Logger";
+import { SOMETHING_HAS_GONE_WRONG, SERVICE_UNAVAILABLE } from "../../constants/app.const";
 import { createPublicOAuthApiClient } from "../api/api.service";
 import { Session } from "@companieshouse/node-session-handler";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
@@ -28,17 +29,17 @@ export const postTransaction = async (session: Session, companyNumber: string, d
   const sdkResponse: Resource<Transaction> | ApiErrorResponse = await apiClient.transaction.postTransaction(transaction);
   
   if (!sdkResponse) {
-    throw createAndLogError(`Transaction API POST request returned no response for company number ${companyNumber}`);
+    throw createAndLogError( SERVICE_UNAVAILABLE, `Transaction API POST request returned no response for company number ${companyNumber}`);
   }
 
   if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= 400) {
-    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to post transaction for company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Http status code ${sdkResponse.httpStatusCode} - Failed to post transaction for company number ${companyNumber}`);
   }
 
   const castedSdkResponse: Resource<Transaction> = sdkResponse as Resource<Transaction>;
 
   if (!castedSdkResponse.resource) {
-    throw createAndLogError(`Transaction API POST request returned no resource for company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Transaction API POST request returned no resource for company number ${companyNumber}`);
   }
 
   logger.debug(`Received transaction ${JSON.stringify(sdkResponse)}`);
@@ -76,11 +77,11 @@ export const putTransaction = async (session: Session,
   const sdkResponse: ApiResponse<Transaction> | ApiErrorResponse = await apiClient.transaction.putTransaction(transaction);
 
   if (!sdkResponse) {
-    throw createAndLogError(`Transaction API PUT request returned no response for transaction id ${transactionId}, company number ${companyNumber}`);
+    throw createAndLogError( SERVICE_UNAVAILABLE, `Transaction API PUT request returned no response for transaction id ${transactionId}, company number ${companyNumber}`);
   }
 
   if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= 400) {
-    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to put transaction for transaction id ${transactionId}, company number ${companyNumber}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Http status code ${sdkResponse.httpStatusCode} - Failed to put transaction for transaction id ${transactionId}, company number ${companyNumber}`);
   }
 
   const castedSdkResponse: ApiResponse<Transaction> = sdkResponse as ApiResponse<Transaction>;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 import { createAndLogError } from "../lib/Logger";
+import { SOMETHING_HAS_GONE_WRONG } from "../constants/app.const";
 
 export const toReadableFormat = (dateToConvert: string): string => {
   if (!dateToConvert) {
@@ -10,7 +11,7 @@ export const toReadableFormat = (dateToConvert: string): string => {
   const convertedDate = dateTime.toFormat("d MMMM yyyy");
 
   if (convertedDate === "Invalid DateTime") {
-    throw createAndLogError(`Unable to convert provided date ${dateToConvert}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `Unable to convert provided date ${dateToConvert}`);
   }
 
   return convertedDate;
@@ -29,7 +30,7 @@ export const toReadableFormatMonthYear = (monthNum: number, year: number): strin
   const convertedMonth = datetime.toFormat("MMMM");
 
   if (convertedMonth === "Invalid DateTime") {
-    throw createAndLogError(`toReadableFormatMonthYear() - Unable to convert provided month ${monthNum}`);
+    throw createAndLogError( SOMETHING_HAS_GONE_WRONG, `toReadableFormatMonthYear() - Unable to convert provided month ${monthNum}`);
   }
 
   return `${convertedMonth} ${year}`;

--- a/src/views/router_views/index/service-unavailable.njk
+++ b/src/views/router_views/index/service-unavailable.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/default.njk" %}
+
+{% block main_content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        Sorry, the service is unavailable
+      </h1>
+      <p class="govuk-body-m">You will be able to use the service later.</p>
+      <p><a href="https://www.gov.uk/contact-companies-house">Contact Companies House</a> if you have any questions.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/test/mocks/company.email.mock.ts
+++ b/test/mocks/company.email.mock.ts
@@ -1,27 +1,16 @@
 jest.mock("../../src/services/company/company.email.service");
+jest.mock("../../src/services/api/private-get-rea/privateApiClient");
 
 import { Resource } from "@companieshouse/api-sdk-node";
-import { companyEmailResource, companyEmail } from "../../src/services/company/resources/resources";
+import { RegisteredEmailAddress } from "../../src/services/api/private-get-rea";
 import { StatusCodes } from 'http-status-codes';
-import { HttpResponse } from "@companieshouse/api-sdk-node/dist/http/http-client";
-import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 
 const validEmail: string = "test@test.co.biz";
-const email: companyEmail = {
-    companyEmail: validEmail
-}
-const OK_RESPONSE_BODY: any = {"registered_email_address": `${validEmail}`};
-
-export const validEmailSDKResource: Resource<companyEmail> = {
-    httpStatusCode: StatusCodes.OK,
-    resource: email
+const email: RegisteredEmailAddress = {
+  registeredEmailAddress: validEmail
 };
 
-export const queryReponse: HttpResponse = {
-    status: StatusCodes.OK,
-    body: OK_RESPONSE_BODY
-};
-
-export const errorReponse: ApiErrorResponse = {
-    httpStatusCode: StatusCodes.INTERNAL_SERVER_ERROR
+export const validEmailSDKResource: Resource<RegisteredEmailAddress> = {
+  httpStatusCode: StatusCodes.OK,
+  resource: email
 };

--- a/test/mocks/company.profile.mock.ts
+++ b/test/mocks/company.profile.mock.ts
@@ -1,7 +1,8 @@
 jest.mock("../../src/services/company/company.profile.service");
 
 import { Resource } from "@companieshouse/api-sdk-node";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
+import { StatusCodes } from 'http-status-codes';
 
 export const validCompanyProfile: CompanyProfile = {
   accounts: {
@@ -44,6 +45,6 @@ export const validCompanyProfile: CompanyProfile = {
 };
 
 export const validSDKResource: Resource<CompanyProfile> = {
-  httpStatusCode: 200,
+  httpStatusCode: StatusCodes.OK,
   resource: validCompanyProfile,
 };

--- a/test/src/routers/email/changeEmailAddress.unit.ts
+++ b/test/src/routers/email/changeEmailAddress.unit.ts
@@ -9,8 +9,7 @@ import { createRequest, createResponse, MockRequest, MockResponse } from 'node-m
 import { ChangeEmailAddressHandler } from "../../../../src/routers/handlers/email/changeEmailAddress";
 import FormValidator from "../../../../src/utils/formValidator.util";
 import { Session } from "@companieshouse/node-session-handler";
-import { COMPANY_EMAIL, NO_EMAIL_ADDRESS_FOUND, NO_EMAIL_ADDRESS_SUPPLIED, EMAIL_ADDRESS_INVALID } from "../../../../src/constants/app.const";
-import { createAndLogError, createAndLogServiceUnavailable } from "../../../../src/lib/Logger";
+import { NO_EMAIL_ADDRESS_FOUND, NO_EMAIL_ADDRESS_SUPPLIED, EMAIL_ADDRESS_INVALID, REGISTERED_EMAIL_ADDRESS } from "../../../../src/constants/app.const";
 
 const COMPANY_NO: string = "1234567";
 const TEST_EMAIL_EXISTING: string = "test@test.co.biz";
@@ -48,7 +47,7 @@ describe("Registered email address update - test GET method", () => {
   
   it("Registered email address update - company email in session", async () => {
     //set email in session
-    request.session?.setExtraData(COMPANY_EMAIL, TEST_EMAIL_EXISTING);
+    request.session?.setExtraData(REGISTERED_EMAIL_ADDRESS, TEST_EMAIL_EXISTING);
 
     await changeEmailAddressHandler.get(request, response).then((changeEmailAddressResponse) => {
       const changeEmailAddressResponseJson = JSON.parse(JSON.stringify(changeEmailAddressResponse));

--- a/test/src/routers/email/changeEmailAddress.unit.ts
+++ b/test/src/routers/email/changeEmailAddress.unit.ts
@@ -9,19 +9,14 @@ import { createRequest, createResponse, MockRequest, MockResponse } from 'node-m
 import { ChangeEmailAddressHandler } from "../../../../src/routers/handlers/email/changeEmailAddress";
 import FormValidator from "../../../../src/utils/formValidator.util";
 import { Session } from "@companieshouse/node-session-handler";
-import { COMPANY_EMAIL, COMPANY_NUMBER, SUBMISSION_ID, TRANSACTION_CREATE_ERROR, NO_EMAIL_ADDRESS_SUPPLIED, EMAIL_ADDRESS_INVALID } from "../../../../src/constants/app.const";
-import { validTransactionSDKResource, transactionId } from "../../../mocks/transaction.mock";
-import { queryReponse, errorReponse } from "../../../mocks/company.email.mock";
-import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
-import { createPublicOAuthApiClient } from "../../../../src/services/api/api.service";
-import { createAndLogError } from "../../../../src/lib/Logger";
+import { COMPANY_EMAIL, NO_EMAIL_ADDRESS_FOUND, NO_EMAIL_ADDRESS_SUPPLIED, EMAIL_ADDRESS_INVALID } from "../../../../src/constants/app.const";
+import { createAndLogError, createAndLogServiceUnavailable } from "../../../../src/lib/Logger";
 
 const COMPANY_NO: string = "1234567";
 const TEST_EMAIL_EXISTING: string = "test@test.co.biz";
 const TEST_EMAIL_UPDATE: string = "new_test@test.co.biz";
 const PAGE_TITLE: string = "Update a registered email address";
 const BACK_LINK_PATH: string = "/registered-email-address/company/confirm";
-const CREATE_TRANSACTION_ERROR: string = TRANSACTION_CREATE_ERROR+COMPANY_NO;
 const INVALID_EMAIL_ADDRESS: string = "test-test.co.biz";
 
 // create form validator instance
@@ -29,36 +24,10 @@ const formValidator = new FormValidator();
 // default handler instance
 let changeEmailAddressHandler: ChangeEmailAddressHandler;
 
-// mocking block - transaction
-const mockCreatePublicOAuthApiClient = createPublicOAuthApiClient as jest.Mock;
-const mockPostTransactionResponse = jest.fn();
-mockCreatePublicOAuthApiClient.mockReturnValue({
-  transaction: {
-    postTransaction: mockPostTransactionResponse
-  }
-});
-
-// mocking block - company email
-const mockCreateApiClient = createApiClient as jest.Mock;
-const mockGetCompanyEmailResponse = jest.fn();
-mockCreateApiClient.mockReturnValue({
-  apiClient: {
-    httpGet: mockGetCompanyEmailResponse
-  }
-});
 // request/response/session
 let session: Session;
 let request: MockRequest<Request>;
 let response: MockResponse<Response>;
-
-// mocking block - logging
-const mockCreateAndLogError = createAndLogError as jest.Mock;
-mockCreateAndLogError.mockReturnValue(new Error());
-
-// clone response processor
-const clone = (objectToClone: any): any => {
-  return JSON.parse(JSON.stringify(objectToClone));
-};
 
 describe("Registered email address update - test GET method", () => {
   // clear down mocks
@@ -77,23 +46,7 @@ describe("Registered email address update - test GET method", () => {
     response = createResponse();
   });
   
-  it("Handle error returned from creating transaction record", async () => {
-    // build required transaction response for test
-    mockPostTransactionResponse.mockResolvedValueOnce(clone(errorReponse));
-    //set company number in session
-    request.session?.setExtraData(COMPANY_NUMBER, COMPANY_NO);
-
-    await changeEmailAddressHandler.get(request, response).then((changeEmailAddressResponse) => {
-      const changeEmailAddressResponseJson = JSON.parse(JSON.stringify(changeEmailAddressResponse));
-
-      expect(changeEmailAddressResponseJson.errors).toBeTruthy;
-      expect(changeEmailAddressResponseJson.backUri).toEqual(BACK_LINK_PATH);
-      expect(changeEmailAddressResponseJson.errors.companyNumber).toEqual(CREATE_TRANSACTION_ERROR);
-    });
-  });
-
   it("Registered email address update - company email in session", async () => {
-    mockPostTransactionResponse.mockResolvedValueOnce(clone(validTransactionSDKResource));
     //set email in session
     request.session?.setExtraData(COMPANY_EMAIL, TEST_EMAIL_EXISTING);
 
@@ -106,22 +59,11 @@ describe("Registered email address update - test GET method", () => {
     });
   });
 
-  it("Valid transaction created", async () => {
-    // build required transaction response for test
-    mockPostTransactionResponse.mockResolvedValueOnce(clone(validTransactionSDKResource));
-    mockGetCompanyEmailResponse.mockResolvedValueOnce(clone(queryReponse));
-    //set company number in session
-    request.session?.setExtraData(COMPANY_NUMBER, COMPANY_NO);
+  it("Registered email address update - company email missing in session", async () => {
 
     await changeEmailAddressHandler.get(request, response).then((changeEmailAddressResponse) => {
       const changeEmailAddressResponseJson = JSON.parse(JSON.stringify(changeEmailAddressResponse));
-
-      expect(changeEmailAddressResponseJson.companyEmailAddress).toEqual(TEST_EMAIL_EXISTING);
-      expect(changeEmailAddressResponseJson.backUri).toEqual(BACK_LINK_PATH);
-      expect(changeEmailAddressResponseJson.userEmail).toEqual(TEST_EMAIL_EXISTING);
-      expect(changeEmailAddressResponseJson.title).toEqual(PAGE_TITLE);
-      expect(request.session?.getExtraData(SUBMISSION_ID)).toBeTruthy;
-      expect(request.session?.getExtraData(SUBMISSION_ID)).toEqual(transactionId);
+      expect(changeEmailAddressResponseJson.errors).toEqual(NO_EMAIL_ADDRESS_FOUND);
     });
   });
 });

--- a/test/src/services/company/company.email.service.unit.ts
+++ b/test/src/services/company/company.email.service.unit.ts
@@ -5,23 +5,19 @@ jest.mock("../../../../src/lib/Logger");
 import { getCompanyEmail } from "../../../../src/services/company/company.email.service";
 import { RegisteredEmailAddress, createPrivateApiClient } from "../../../../src/services/api/private-get-rea";
 import { Resource } from "@companieshouse/api-sdk-node";
-import { createAndLogError, createAndLogServiceUnavailable } from "../../../../src/lib/Logger";
+import { createAndLogError  } from "../../../../src/lib/Logger";
 import { validEmailSDKResource } from "../../../mocks/company.email.mock";
 import { StatusCodes } from 'http-status-codes';
+import { SERVICE_UNAVAILABLE, SOMETHING_HAS_GONE_WRONG } from "../../../../src/constants/app.const";
 
 const mockCreatePrivateApiClient = createPrivateApiClient as jest.Mock;
 const mockGetRegisteredEmailAddress = jest.fn();
-const mockCreateAndLogError = createAndLogError as jest.Mock;
-const mockCreateAndLogServiceUnavailable = createAndLogServiceUnavailable as jest.Mock;
 
 mockCreatePrivateApiClient.mockReturnValue({
   registeredEmailAddress: {
     getRegisteredEmailAddress: mockGetRegisteredEmailAddress
   }
 });
-
-mockCreateAndLogError.mockReturnValue(new Error());
-mockCreateAndLogServiceUnavailable.mockReturnValue(new Error());
 
 const clone = (objectToClone: any): any => {
   return JSON.parse(JSON.stringify(objectToClone));
@@ -48,13 +44,12 @@ describe("Company email address service test", () => {
     it("Should throw an error if no response returned from SDK", async () => {
       mockGetRegisteredEmailAddress.mockResolvedValueOnce(undefined);
 
-      await getCompanyEmail(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyEmail(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining("Registered email address API"));
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(SERVICE_UNAVAILABLE));
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("Registered email address API"));
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });
 
@@ -64,13 +59,12 @@ describe("Company email address service test", () => {
         httpStatusCode: HTTP_STATUS_CODE
       } as Resource<RegisteredEmailAddress>);
 
-      await getCompanyEmail(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyEmail(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining("Registered email address API"));
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+          expect(createAndLogError).toHaveBeenCalledWith(SERVICE_UNAVAILABLE);
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("Registered email address API"));
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });
 
@@ -80,28 +74,26 @@ describe("Company email address service test", () => {
         httpStatusCode: HTTP_STATUS_CODE
       } as Resource<RegisteredEmailAddress>);
 
-      await getCompanyEmail(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyEmail(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(SOMETHING_HAS_GONE_WRONG);
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${StatusCodes.BAD_REQUEST}`));
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });
 
     it("Should throw an error if no response resource returned from SDK", async () => {
+      console.log("Should throw an error if no response resource returned from SDK");
       mockGetRegisteredEmailAddress.mockResolvedValueOnce({} as Resource<RegisteredEmailAddress>);
 
-      await getCompanyEmail(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyEmail(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(SOMETHING_HAS_GONE_WRONG);
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("no resource"));
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });
   });
 });
-

--- a/test/src/services/company/company.profile.service.unit.ts
+++ b/test/src/services/company/company.profile.service.unit.ts
@@ -1,7 +1,8 @@
 import { getCompanyProfile } from "../../../../src/services/company/company.profile.service";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
-import { createAndLogError, createAndLogServiceUnavailable } from "../../../../src/lib/Logger";
+import { createAndLogError } from "../../../../src/lib/Logger";
+import { SOMETHING_HAS_GONE_WRONG, SERVICE_UNAVAILABLE } from "../../../../src/constants/app.const";
 import { validSDKResource } from "../../../mocks/company.profile.mock";
 import { StatusCodes } from "http-status-codes";
 jest.mock("@companieshouse/api-sdk-node");
@@ -9,8 +10,6 @@ jest.mock("../../../../src/lib/Logger");
 
 const mockCreateApiClient = createApiClient as jest.Mock;
 const mockGetCompanyProfile = jest.fn();
-const mockCreateAndLogError = createAndLogError as jest.Mock;
-const mockCreateAndLogServiceUnavailable = createAndLogServiceUnavailable as jest.Mock;
 
 mockCreateApiClient.mockReturnValue({
   companyProfile: {
@@ -18,8 +17,6 @@ mockCreateApiClient.mockReturnValue({
   }
 });
 
-mockCreateAndLogError.mockReturnValue(new Error());
-mockCreateAndLogServiceUnavailable.mockReturnValue(new Error());
 
 const clone = (objectToClone: any): any => {
   return JSON.parse(JSON.stringify(objectToClone));
@@ -45,13 +42,12 @@ describe("Company profile service test", () => {
     it("Should throw an error if no response returned from SDK", async () => {
       mockGetCompanyProfile.mockResolvedValueOnce(undefined);
 
-      await getCompanyProfile(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyProfile(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining("Company profile API"));
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+          expect(createAndLogError).toHaveBeenCalledWith(SERVICE_UNAVAILABLE);
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("Company profile API"));
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });
 
@@ -61,13 +57,12 @@ describe("Company profile service test", () => {
         httpStatusCode: HTTP_STATUS_CODE
       } as Resource<CompanyProfile>);
 
-      await getCompanyProfile(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyProfile(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining("Company profile API"));
-          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+          expect(createAndLogError).toHaveBeenCalledWith(SERVICE_UNAVAILABLE);
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("Company profile API"));
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });
 
@@ -77,11 +72,10 @@ describe("Company profile service test", () => {
         httpStatusCode: HTTP_STATUS_CODE
       } as Resource<CompanyProfile>);
 
-      await getCompanyProfile(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyProfile(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(SOMETHING_HAS_GONE_WRONG);
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${HTTP_STATUS_CODE}`));
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
@@ -90,11 +84,10 @@ describe("Company profile service test", () => {
     it("Should throw an error if no response resource returned from SDK", async () => {
       mockGetCompanyProfile.mockResolvedValueOnce({} as Resource<CompanyProfile>);
 
-      await getCompanyProfile(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
+      await expect(getCompanyProfile(COMPANY_NUMBER))
+        .rejects.toBe(undefined)
         .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(SOMETHING_HAS_GONE_WRONG);
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("no resource"));
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });

--- a/test/src/services/company/company.profile.service.unit.ts
+++ b/test/src/services/company/company.profile.service.unit.ts
@@ -1,7 +1,7 @@
 import { getCompanyProfile } from "../../../../src/services/company/company.profile.service";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
-import { createAndLogError } from "../../../../src/lib/Logger";
+import { createAndLogError, createAndLogServiceUnavailable } from "../../../../src/lib/Logger";
 import { validSDKResource } from "../../../mocks/company.profile.mock";
 import { StatusCodes } from "http-status-codes";
 jest.mock("@companieshouse/api-sdk-node");
@@ -10,6 +10,7 @@ jest.mock("../../../../src/lib/Logger");
 const mockCreateApiClient = createApiClient as jest.Mock;
 const mockGetCompanyProfile = jest.fn();
 const mockCreateAndLogError = createAndLogError as jest.Mock;
+const mockCreateAndLogServiceUnavailable = createAndLogServiceUnavailable as jest.Mock;
 
 mockCreateApiClient.mockReturnValue({
   companyProfile: {
@@ -18,6 +19,7 @@ mockCreateApiClient.mockReturnValue({
 });
 
 mockCreateAndLogError.mockReturnValue(new Error());
+mockCreateAndLogServiceUnavailable.mockReturnValue(new Error());
 
 const clone = (objectToClone: any): any => {
   return JSON.parse(JSON.stringify(objectToClone));
@@ -40,6 +42,35 @@ describe("Company profile service test", () => {
       });
     });
 
+    it("Should throw an error if no response returned from SDK", async () => {
+      mockGetCompanyProfile.mockResolvedValueOnce(undefined);
+
+      await getCompanyProfile(COMPANY_NUMBER)
+        .then(() => {
+          fail("Was expecting an error to be thrown.");
+        })
+        .catch(() => {
+          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining("Company profile API"));
+          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+        });
+    });
+
+    it("Should throw an error if SERVICE UNAVAILABLE returned from SDK", async () => {
+      const HTTP_STATUS_CODE = StatusCodes.SERVICE_UNAVAILABLE;
+      mockGetCompanyProfile.mockResolvedValueOnce({
+        httpStatusCode: HTTP_STATUS_CODE
+      } as Resource<CompanyProfile>);
+
+      await getCompanyProfile(COMPANY_NUMBER)
+        .then(() => {
+          fail("Was expecting an error to be thrown.");
+        })
+        .catch(() => {
+          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining("Company profile API"));
+          expect(createAndLogServiceUnavailable).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+        });
+    });
+
     it(`Should throw an error if status code >= ${StatusCodes.BAD_REQUEST}`, async () => {
       const HTTP_STATUS_CODE = StatusCodes.BAD_REQUEST;
       mockGetCompanyProfile.mockResolvedValueOnce({
@@ -52,19 +83,6 @@ describe("Company profile service test", () => {
         })
         .catch(() => {
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${HTTP_STATUS_CODE}`));
-          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
-        });
-    });
-
-    it("Should throw an error if no response returned from SDK", async () => {
-      mockGetCompanyProfile.mockResolvedValueOnce(undefined);
-
-      await getCompanyProfile(COMPANY_NUMBER)
-        .then(() => {
-          fail("Was expecting an error to be thrown.");
-        })
-        .catch(() => {
-          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("no response"));
           expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
         });
     });

--- a/test/src/services/transaction/transaction.service.unit.ts
+++ b/test/src/services/transaction/transaction.service.unit.ts
@@ -10,12 +10,12 @@ import { createAndLogError } from "../../../../src/lib/Logger";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { REFERENCE } from "../../../../src/config/index";
 import { StatusCodes } from 'http-status-codes';
+import { SERVICE_UNAVAILABLE, SOMETHING_HAS_GONE_WRONG } from "../../../../src/constants/app.const";
 
 const mockCreatePublicOAuthApiClient = createPublicOAuthApiClient as jest.Mock;
 const mockPostTransaction = jest.fn();
 const mockPutTransaction = jest.fn();
 const mockGetTransaction = jest.fn();
-const mockCreateAndLogError = createAndLogError as jest.Mock;
 
 mockCreatePublicOAuthApiClient.mockReturnValue({
   transaction: {
@@ -24,9 +24,6 @@ mockCreatePublicOAuthApiClient.mockReturnValue({
     putTransaction: mockPutTransaction
   }
 });
-
-const ERROR: Error = new Error("oops");
-mockCreateAndLogError.mockReturnValue(ERROR);
 
 let session: any;
 const TRANSACTION_ID = "2222";
@@ -60,8 +57,12 @@ describe("transaction service tests", () => {
     it("Should throw an error when no transaction api response", async () => {
       mockPostTransaction.mockResolvedValueOnce(undefined);
 
-      await expect(postTransaction(session, COMPANY_NUMBER, "desc", "ref")).rejects.toThrow(ERROR);
-      expect(mockCreateAndLogError).toBeCalledWith("Transaction API POST request returned no response for company number 12345678");
+      await expect(postTransaction(session, COMPANY_NUMBER, "desc", "ref"))
+        .rejects.toBe(undefined)
+        .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(SERVICE_UNAVAILABLE);
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("Transaction API POST request returned no response for company number 12345678"));
+        });
     });
 
     it("Should throw an error when transaction api returns a status greater than 400", async () => {
@@ -69,8 +70,12 @@ describe("transaction service tests", () => {
         httpStatusCode: StatusCodes.NOT_FOUND
       });
 
-      await expect(postTransaction(session, COMPANY_NUMBER, "desc", "ref")).rejects.toThrow(ERROR);
-      expect(mockCreateAndLogError).toBeCalledWith(`Http status code ${StatusCodes.NOT_FOUND} - Failed to post transaction for company number 12345678`);
+      await expect(postTransaction(session, COMPANY_NUMBER, "desc", "ref"))
+        .rejects.toBe(undefined)
+        .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(SOMETHING_HAS_GONE_WRONG);
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`Http status code ${StatusCodes.NOT_FOUND} - Failed to post transaction for company number 12345678`));
+        });
     });
 
     it("Should throw an error when transaction api returns no resource", async () => {
@@ -78,8 +83,12 @@ describe("transaction service tests", () => {
         httpStatusCode: StatusCodes.OK
       });
 
-      await expect(postTransaction(session, COMPANY_NUMBER, "desc", "ref")).rejects.toThrow(ERROR);
-      expect(mockCreateAndLogError).toBeCalledWith("Transaction API POST request returned no resource for company number 12345678");
+      await expect(postTransaction(session, COMPANY_NUMBER, "desc", "ref"))
+        .rejects.toBe(undefined)
+        .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(SOMETHING_HAS_GONE_WRONG));
+          expect(createAndLogError).toBeCalledWith(expect.stringContaining("Transaction API POST request returned no resource for company number 12345678"));
+        });
     });
   });
 
@@ -113,8 +122,13 @@ describe("transaction service tests", () => {
     it("Should throw an error when no transaction api response", async () => {
       mockPutTransaction.mockResolvedValueOnce(undefined);
 
-      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
-      expect(mockCreateAndLogError).toBeCalledWith(`Transaction API PUT request returned no response for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
+      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "closed"))
+        .rejects.toBe(undefined)
+        .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(SERVICE_UNAVAILABLE));
+          expect(createAndLogError).toBeCalledWith(expect.stringContaining(`Transaction API PUT request returned no response for transaction id ${TRANSACTION_ID}`));
+          expect(createAndLogError).toBeCalledWith(expect.stringContaining(`company number ${COMPANY_NUMBER}`));
+        });
     });
 
     it("Should throw an error when transaction api returns a status greater than 400", async () => {
@@ -122,8 +136,12 @@ describe("transaction service tests", () => {
         httpStatusCode: StatusCodes.NOT_FOUND
       });
 
-      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
-      expect(mockCreateAndLogError).toBeCalledWith(`Http status code ${StatusCodes.NOT_FOUND} - Failed to put transaction for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
+      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "closed"))
+        .rejects.toBe(undefined)
+        .catch(() => {
+          expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(SOMETHING_HAS_GONE_WRONG));
+          expect(createAndLogError).toBeCalledWith(`Http status code ${StatusCodes.NOT_FOUND} - Failed to put transaction for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
+        });
     });
   });
 


### PR DESCRIPTION
New screen created
private version of api-sdk-node for get registered-email-address oracle-query-api
added a name to createAndLogError calls for exception handling
aligned company-profile and company-email services to use exception handling to trap specific 503 failures
exception handling in unit tests updated
trapped SERVICE_UNAVAILABLE failures to redirect to new screen
resulted in some placeholders for SOMETHING_HAS_GONE_WRONG scenarios
removal of some unnecessary code