### PR TITLE
ECCT-388 add configuration items for timeouts

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -39,6 +39,8 @@ export const PIWIK_UPDATE_START_GOAL_ID = getEnvironmentValue("PIWIK_UPDATE_STAR
 export const LOG_LEVEL = getEnvironmentValue("LOG_LEVEL", "DEBUG");
 export const API_URL = getEnvironmentValue("API_URL", "http://api.chs.local:4001");
 export const ACCOUNT_URL = getEnvironmentValue("ACCOUNT_URL", "http://account.chs.local");
+export const SESSION_TIMEOUT = getEnvironmentValue("SESSION_TIMEOUT", undefined);
+export const SESSION_COUNTDOWN = getEnvironmentValue("SESSION_COUNTDOWN", undefined);
 
 export const DESCRIPTION = "Update Registered Email Address Transaction";
 export const REFERENCE = "UpdateRegisteredEmailAddressReference";

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -4,6 +4,7 @@ import { BaseHttpController } from "inversify-express-utils";
 import "reflect-metadata";
 
 import errorManifest from "../../utils/error/errorManifest";
+import { SESSION_COUNTDOWN, SESSION_TIMEOUT } from "../../config";
 
 export abstract class GenericHandler extends BaseHttpController {
 
@@ -15,6 +16,8 @@ export abstract class GenericHandler extends BaseHttpController {
     this.errorManifest = errorManifest;
     this.viewData = {};
     this.viewData.signoutBanner = true;
+    this.viewData.sessionTimeout = SESSION_TIMEOUT;
+    this.viewData.sessionCountdown = SESSION_COUNTDOWN;
   }
 
   processHandlerException (err: any): Object {

--- a/src/views/layouts/layout.njk
+++ b/src/views/layouts/layout.njk
@@ -79,7 +79,9 @@
   {% if signoutBanner %}
     {% if userEmail %}
       <script src="//{{ cdnHost }}/javascripts/app/session-timeout.js"></script>
-      {# <script>$.timeoutDialog ({ timeout: 30, countdown: 15 })</script> #}
+      {% if sessionTimeout %}
+        <script>$.timeoutDialog ({ timeout: {{ sessionTimeout }}, countdown: {{ sessionCountdown }} })</script>
+      {% endif %}
     {% endif %}
   {% endif %}
   <script src="//{{ cdnHost }}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js"></script>


### PR DESCRIPTION
Created Environment variables to allow testers to set SESSION_TIMEOUT and SESSION_COUNTDOWN parameters