### PR TITLE
Update to Update Submitted wiring to handle post event.

### DIFF
--- a/src/routers/emailRouter.ts
+++ b/src/routers/emailRouter.ts
@@ -76,4 +76,12 @@ emailRouter.get(UPDATE_SUBMITTED, async (req: Request, res: Response, next: Next
   });
 });
 
+// POST: /update-submitted
+emailRouter.get(UPDATE_SUBMITTED, async (req: Request, res: Response, next: NextFunction) => {
+  const handler = new UpdateSubmittedHandler();
+  await handler.post(req, res).then((viewData) => {
+    res.render(`${emailRouterViews}` + UPDATE_SUBMITTED, viewData);
+  });
+});
+
 export default emailRouter;

--- a/src/routers/handlers/email/updateSubmitted.ts
+++ b/src/routers/handlers/email/updateSubmitted.ts
@@ -30,9 +30,21 @@ export class UpdateSubmittedHandler extends GenericHandler {
     // clear session.ExtraData
     session.setExtraData(COMPANY_PROFILE, undefined);
     session.setExtraData(COMPANY_NUMBER, undefined);
-    session.setExtraData(REGISTERED_EMAIL_ADDRESS, undefined);
     session.setExtraData(NEW_EMAIL_ADDRESS, undefined);
     session.setExtraData(INVALID_COMPANY_REASON, undefined);
+
+    return Promise.resolve(this.viewData);
+  }
+
+  async post (req: Request, response: Response): Promise<Object> {
+    logger.info(`POST request to serve update submitted page`);
+    const session: Session = req.session as Session;
+    this.viewData.userEmail = session.getExtraData(REGISTERED_EMAIL_ADDRESS);
+    this.viewData.backUri = undefined;
+    this.viewData.submissionID = session.getExtraData(SUBMISSION_ID);
+
+    // clear session.ExtraData
+    session.setExtraData(REGISTERED_EMAIL_ADDRESS, undefined);
     session.setExtraData(SUBMISSION_ID, undefined);
 
     return Promise.resolve(this.viewData);

--- a/test/src/routers/handlers/email/updateSubmitted.unit.ts
+++ b/test/src/routers/handlers/email/updateSubmitted.unit.ts
@@ -4,7 +4,7 @@ import { createRequest, createResponse, MockRequest, MockResponse } from 'node-m
 import { UpdateSubmittedHandler } from "../../../../../src/routers/handlers/email/updateSubmitted";
 import { Session } from "@companieshouse/node-session-handler";
 import { createSessionData } from "../../../../mocks/sessionGenerator.mock";
-import { SUBMISSION_ID } from "../../../../../src/constants/app.const";
+import { SUBMISSION_ID, REGISTERED_EMAIL_ADDRESS} from "../../../../../src/constants/app.const";
 import * as crypto from "crypto";
 
 const TEST_USER_EMAIL: string = "test_user@test.co.biz";
@@ -32,6 +32,28 @@ describe("Registered email address update - test GET method", () => {
     request.session?.setExtraData(SUBMISSION_ID, TEST_SUBMISSION_ID);
 
     await updateSubmittedHandler.get(request, response).then((updateSubmittedResponse) => {
+      const updateSubmittedResponseJson = JSON.parse(JSON.stringify(updateSubmittedResponse));
+
+      expect(updateSubmittedResponseJson.userEmail).toEqual(TEST_USER_EMAIL);
+      expect(updateSubmittedResponseJson.submissionID).toEqual(TEST_SUBMISSION_ID);
+    });
+  });
+});
+
+describe("Registered email address update - test POST method", () => {  
+  it("Required submission data in object returned from handler", async () => {
+    // mock request/responses
+    request = createRequest({
+      session: new Session({ 
+        ...createSessionData(cookieSecret)
+      })
+    });
+
+    // set submission id and REA in session
+    request.session?.setExtraData(SUBMISSION_ID, TEST_SUBMISSION_ID);
+    request.session?.setExtraData(REGISTERED_EMAIL_ADDRESS, TEST_USER_EMAIL);
+
+    await updateSubmittedHandler.post(request, response).then((updateSubmittedResponse) => {
       const updateSubmittedResponseJson = JSON.parse(JSON.stringify(updateSubmittedResponse));
 
       expect(updateSubmittedResponseJson.userEmail).toEqual(TEST_USER_EMAIL);


### PR DESCRIPTION
As per title. On `Update submitted` page refresh, `submission id` was not present. PR addresses issue.