### PR TITLE
Handle when service is called from Confirmation Statement service

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,11 +1,11 @@
-import { getEnvironmentValue } from "../utils/environment/environment_value";
+import {getEnvironmentValue} from "../utils/environment/environment_value";
 
 // URL params
 export enum urlParams {
-    PARAM_COMPANY_NUMBER = "companyNumber",
-    PARAM_TRANSACTION_ID = "transactionId",
-    PARAM_SUBMISSION_ID = "submissionId",
-    PARAM_APPOINTMENT_ID = "appointmentId"
+  PARAM_COMPANY_NUMBER = "companyNumber",
+  PARAM_TRANSACTION_ID = "transactionId",
+  PARAM_SUBMISSION_ID = "submissionId",
+  PARAM_APPOINTMENT_ID = "appointmentId"
 }
 
 // Transaction statuses
@@ -38,7 +38,7 @@ export const SESSION_COUNTDOWN = getEnvironmentValue("SESSION_COUNTDOWN");
 export const ORACLE_QUERY_API_URL = getEnvironmentValue("ORACLE_QUERY_API_URL", "http://api.chs.local:4001");
 
 export const FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/update-reg-email-addr-fdbck/";
-export const CONFIRMATION_FEEDBACK_LINK =  'https://www.smartsurvey.co.uk/s/update-reg-email-addr-conf/';
+export const CONFIRMATION_FEEDBACK_LINK = 'https://www.smartsurvey.co.uk/s/update-reg-email-addr-conf/';
 export const DESCRIPTION = "Update Registered Email Address Transaction";
 export const REFERENCE = "UpdateRegisteredEmailAddressReference_";
 export const STATIC_SUBMISSION_ID = "72hw92jw992km90mw9002m22";
@@ -47,7 +47,7 @@ export const VALID_EMAIL_REGEX_PATTERN = ".+[@].+[.].+";
 // TEMPLATES
 export const HOME_PAGE = "home";
 export const REA_HOME_PAGE = "/registered-email-address";
-export const COMPANY_LOOKUP_PAGE  = "/company-lookup";
+export const COMPANY_LOOKUP_PAGE = "/company-lookup";
 export const COMPANY_NUMBER_PAGE = "company/number";
 export const COMPANY_CONFIRM_PAGE = "company/confirm";
 export const EMAIL_CHANGE_EMAIL_ADDRESS = "email/change-email-address";
@@ -57,6 +57,7 @@ export const COMPANY_INVALID_PAGE = "invalid";
 export const SIGN_OUT_PAGE = `signout`;
 export const ACCESSIBILITY_STATEMENT_PAGE = "accessibility-statement";
 export const THERE_IS_A_PROBLEM_PAGE = "there-is-a-problem";
+export const CS_HOME_PAGE = "/confirmation-statement";
 
 
 // ROUTING PATHS
@@ -69,6 +70,7 @@ export const INVALID_URL = "/invalid";
 export const CHANGE_EMAIL_ADDRESS_URL = "/change-email-address";
 export const CHECK_ANSWER_URL = "/check-your-answer";
 export const UPDATE_SUBMITTED = "/update-submitted";
+export const CONFIRMATION_STATEMENT_RETURN = `return-from-rea`;
 
 // FULL URLS
 export const SIGN_OUT_URL = `${HOME_URL}/${SIGN_OUT_PAGE}`;
@@ -82,3 +84,4 @@ export const ACCESSIBILITY_STATEMENT_URL = `${HOME_URL}/${ACCESSIBILITY_STATEMEN
 export const EMAIL_UPDATE_SUBMITTED_URL = `${HOME_URL}/${EMAIL_UPDATE_SUBMITTED}`;
 export const THERE_IS_A_PROBLEM_URL = `${HOME_URL}/${THERE_IS_A_PROBLEM_PAGE}`;
 export const COMPANY_LOOKUP_URL = `${COMPANY_LOOKUP_PAGE}/search?forward=${COMPANY_CONFIRM_URL}?companyNumber={companyNumber}`;
+export const CONFIRMATION_STATEMENT_RETURN_URL = `${CS_HOME_PAGE}/${CONFIRMATION_STATEMENT_RETURN}`;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -57,7 +57,6 @@ export const COMPANY_INVALID_PAGE = "invalid";
 export const SIGN_OUT_PAGE = `signout`;
 export const ACCESSIBILITY_STATEMENT_PAGE = "accessibility-statement";
 export const THERE_IS_A_PROBLEM_PAGE = "there-is-a-problem";
-export const CS_HOME_PAGE = "/confirmation-statement";
 
 
 // ROUTING PATHS
@@ -70,7 +69,6 @@ export const INVALID_URL = "/invalid";
 export const CHANGE_EMAIL_ADDRESS_URL = "/change-email-address";
 export const CHECK_ANSWER_URL = "/check-your-answer";
 export const UPDATE_SUBMITTED = "/update-submitted";
-export const CONFIRMATION_STATEMENT_RETURN = `return-from-rea`;
 
 // FULL URLS
 export const SIGN_OUT_URL = `${HOME_URL}/${SIGN_OUT_PAGE}`;
@@ -84,4 +82,3 @@ export const ACCESSIBILITY_STATEMENT_URL = `${HOME_URL}/${ACCESSIBILITY_STATEMEN
 export const EMAIL_UPDATE_SUBMITTED_URL = `${HOME_URL}/${EMAIL_UPDATE_SUBMITTED}`;
 export const THERE_IS_A_PROBLEM_URL = `${HOME_URL}/${THERE_IS_A_PROBLEM_PAGE}`;
 export const COMPANY_LOOKUP_URL = `${COMPANY_LOOKUP_PAGE}/search?forward=${COMPANY_CONFIRM_URL}?companyNumber={companyNumber}`;
-export const CONFIRMATION_STATEMENT_RETURN_URL = `${CS_HOME_PAGE}/${CONFIRMATION_STATEMENT_RETURN}`;

--- a/src/constants/app_const.ts
+++ b/src/constants/app_const.ts
@@ -7,6 +7,7 @@ export const INVALID_COMPANY_REASON: string = "invalidCompanyReason";
 export const RETURN_URL: string = 'returnToUrl';
 export const SUBMISSION_ID: string = "submissionID";
 export const RETURN_TO_CONFIRMATION_STATEMENT: string = "returnToConfirmationStatement";
+export const CONFIRMATION_STATEMENT_RETURN_URL: string = "confirmationStatementReturnUrl";
 export const REGISTERED_EMAIL_ADDRESS_SUBMITTED: string = "registeredEmailAddressSubmitted";
 
 export const THERE_IS_A_PROBLEM_ERROR: string = "There is a problem";

--- a/src/constants/app_const.ts
+++ b/src/constants/app_const.ts
@@ -1,27 +1,28 @@
 // session.extra_data
-export const COMPANY_PROFILE: string =  "companyProfile";
-export const COMPANY_NUMBER: string =  "companyNumber";
-export const REGISTERED_EMAIL_ADDRESS: string =  "registeredEmailAddress";
-export const NEW_EMAIL_ADDRESS: string =  "newEmailAddress";
-export const INVALID_COMPANY_REASON: string =  "invalidCompanyReason";
-export const RETURN_URL: string =  'returnToUrl';
-export const SUBMISSION_ID: string =  "submissionID";
+export const COMPANY_PROFILE: string = "companyProfile";
+export const COMPANY_NUMBER: string = "companyNumber";
+export const REGISTERED_EMAIL_ADDRESS: string = "registeredEmailAddress";
+export const NEW_EMAIL_ADDRESS: string = "newEmailAddress";
+export const INVALID_COMPANY_REASON: string = "invalidCompanyReason";
+export const RETURN_URL: string = 'returnToUrl';
+export const SUBMISSION_ID: string = "submissionID";
+export const RETURN_TO_CONFIRMATION_STATEMENT: string = "returnToConfirmationStatement";
+export const REGISTERED_EMAIL_ADDRESS_SUBMITTED: string = "registeredEmailAddressSubmitted";
 
-
-export const THERE_IS_A_PROBLEM_ERROR: string =  "There is a problem";
-export const INVALID_COMPANY_NUMBER: string =  "You must enter a valid company number";
-export const NO_EMAIL_ADDRESS_FOUND: string =  "No email address for company number";
-export const EMAIL_ADDRESS_INVALID: string =  "Enter an email address in the correct format, like name@example.com";
-export const NO_EMAIL_ADDRESS_SUPPLIED: string =  "Enter the registered email address";
-export const TRANSACTION_CREATE_ERROR: string =  "Unable to create a transaction record for company ";
-export const TRANSACTION_CLOSE_ERROR: string =  "Unable to close a transaction record for company ";
-export const CONFIRM_EMAIL_CHANGE_ERROR: string =  "You need to accept the registered email address statement";
-export const FAILED_TO_CREATE_REA_ERROR: string =  "Failed to create Registered Email Address Resource for company ";
+export const THERE_IS_A_PROBLEM_ERROR: string = "There is a problem";
+export const INVALID_COMPANY_NUMBER: string = "You must enter a valid company number";
+export const NO_EMAIL_ADDRESS_FOUND: string = "No email address for company number";
+export const EMAIL_ADDRESS_INVALID: string = "Enter an email address in the correct format, like name@example.com";
+export const NO_EMAIL_ADDRESS_SUPPLIED: string = "Enter the registered email address";
+export const TRANSACTION_CREATE_ERROR: string = "Unable to create a transaction record for company ";
+export const TRANSACTION_CLOSE_ERROR: string = "Unable to close a transaction record for company ";
+export const CONFIRM_EMAIL_CHANGE_ERROR: string = "You need to accept the registered email address statement";
+export const FAILED_TO_CREATE_REA_ERROR: string = "Failed to create Registered Email Address Resource for company ";
 export const FAILED_TO_FIND_RETURN_URL_ERROR: string = "Unable to find return page";
-export const PRIVATE_API_ERROR: string =  "You cannot set both api key and oauth token to create a client. Please use one or the other";
+export const PRIVATE_API_ERROR: string = "You cannot set both api key and oauth token to create a client. Please use one or the other";
 
 // erroring constants
-export const UPDATE_EMAIL_ERROR_KEY: string =  "changeEmailAddress";
-export const UPDATE_EMAIL_ERROR_ANCHOR: string =  "#change-email-address";
-export const CHECK_ANSWER_ERROR_KEY: string =  "acceptAppropriateEmailAddressStatement";
-export const CHECK_ANSWER_ERROR_ANCHOR: string =  "#acceptAppropriateEmailAddressStatement";
+export const UPDATE_EMAIL_ERROR_KEY: string = "changeEmailAddress";
+export const UPDATE_EMAIL_ERROR_ANCHOR: string = "#change-email-address";
+export const CHECK_ANSWER_ERROR_KEY: string = "acceptAppropriateEmailAddressStatement";
+export const CHECK_ANSWER_ERROR_ANCHOR: string = "#acceptAppropriateEmailAddressStatement";

--- a/src/routers/email_router.ts
+++ b/src/routers/email_router.ts
@@ -7,13 +7,14 @@ import {CheckAnswerHandler} from "./handlers/email/check_answer";
 import {
   CHANGE_EMAIL_ADDRESS_URL,
   CHECK_ANSWER_URL,
+  CONFIRMATION_STATEMENT_RETURN_URL,
   EMAIL_CHECK_ANSWER_URL,
-  THERE_IS_A_PROBLEM_URL,
   EMAIL_UPDATE_SUBMITTED_URL,
+  THERE_IS_A_PROBLEM_URL,
   UPDATE_SUBMITTED
 } from "../config";
 
-import { CONFIRM_EMAIL_CHANGE_ERROR } from "../constants/app_const";
+import {CONFIRM_EMAIL_CHANGE_ERROR} from "../constants/app_const";
 
 const email_router: Router = Router();
 const emailRouterViews: string = "router-views/email/";
@@ -73,6 +74,14 @@ email_router.get(UPDATE_SUBMITTED, async (req: Request, res: Response, next: Nex
   const handler = new UpdateSubmittedHandler();
   await handler.get(req, res).then((viewData) => {
     res.render(`${emailRouterViews}` + UPDATE_SUBMITTED, viewData);
+  });
+});
+
+// POST: /update-submitted
+email_router.post(UPDATE_SUBMITTED, async (req: Request, res: Response, next: NextFunction) => {
+  const handler = new UpdateSubmittedHandler();
+  await handler.post(req, res).then((viewData) => {
+    res.redirect(CONFIRMATION_STATEMENT_RETURN_URL);
   });
 });
 

--- a/src/routers/email_router.ts
+++ b/src/routers/email_router.ts
@@ -7,14 +7,13 @@ import {CheckAnswerHandler} from "./handlers/email/check_answer";
 import {
   CHANGE_EMAIL_ADDRESS_URL,
   CHECK_ANSWER_URL,
-  CONFIRMATION_STATEMENT_RETURN_URL,
   EMAIL_CHECK_ANSWER_URL,
   EMAIL_UPDATE_SUBMITTED_URL,
   THERE_IS_A_PROBLEM_URL,
   UPDATE_SUBMITTED
 } from "../config";
 
-import {CONFIRM_EMAIL_CHANGE_ERROR} from "../constants/app_const";
+import {CONFIRMATION_STATEMENT_RETURN_URL, CONFIRM_EMAIL_CHANGE_ERROR, RETURN_TO_CONFIRMATION_STATEMENT} from "../constants/app_const";
 
 const email_router: Router = Router();
 const emailRouterViews: string = "router-views/email/";
@@ -81,7 +80,12 @@ email_router.get(UPDATE_SUBMITTED, async (req: Request, res: Response, next: Nex
 email_router.post(UPDATE_SUBMITTED, async (req: Request, res: Response, next: NextFunction) => {
   const handler = new UpdateSubmittedHandler();
   await handler.post(req, res).then((viewData) => {
-    res.redirect(CONFIRMATION_STATEMENT_RETURN_URL);
+    const confirmationStatementReturnUrl: string = req.session?.getExtraData(CONFIRMATION_STATEMENT_RETURN_URL) as string;
+    if (confirmationStatementReturnUrl) {
+      res.redirect(confirmationStatementReturnUrl);
+    } else {
+      res.redirect(THERE_IS_A_PROBLEM_URL);
+    }
   });
 });
 

--- a/src/routers/handlers/email/change_email_address.ts
+++ b/src/routers/handlers/email/change_email_address.ts
@@ -1,49 +1,52 @@
-import { Request, Response } from "express";
-import { GenericHandler } from "../generic";
-import { inject } from "inversify";
-import { Session } from "@companieshouse/node-session-handler";
-import { logger } from "../../../utils/common/logger";
-import { validateEmailString } from "../../../utils/email/validate_email_string";
-import { postTransaction } from "../../../services/transaction/transaction_service";
-import { formatValidationError } from "../../../utils/error/format_validation_errors";
+import {Request, Response} from "express";
+import {GenericHandler} from "../generic";
+import {inject} from "inversify";
+import {Session} from "@companieshouse/node-session-handler";
+import {logger} from "../../../utils/common/logger";
+import {validateEmailString} from "../../../utils/email/validate_email_string";
+import {postTransaction} from "../../../services/transaction/transaction_service";
+import {formatValidationError} from "../../../utils/error/format_validation_errors";
 
 import {
   COMPANY_NUMBER,
-  SUBMISSION_ID,
-  NO_EMAIL_ADDRESS_FOUND,
+  COMPANY_PROFILE,
   EMAIL_ADDRESS_INVALID,
   NEW_EMAIL_ADDRESS,
+  NO_EMAIL_ADDRESS_FOUND,
   REGISTERED_EMAIL_ADDRESS,
+  REGISTERED_EMAIL_ADDRESS_SUBMITTED,
+  RETURN_TO_CONFIRMATION_STATEMENT,
+  SUBMISSION_ID,
   TRANSACTION_CREATE_ERROR,
-  UPDATE_EMAIL_ERROR_KEY,
   UPDATE_EMAIL_ERROR_ANCHOR,
-  COMPANY_PROFILE
+  UPDATE_EMAIL_ERROR_KEY
 } from "../../../constants/app_const";
 
 import {
   COMPANY_BASE_URL,
   CONFIRM_URL,
+  CONFIRMATION_STATEMENT_RETURN_URL,
   DESCRIPTION,
   REFERENCE
 } from "../../../config";
 
 import ValidationErrors from "../../../models/validation_errors";
 
-import { StatusCodes } from 'http-status-codes';
+import {StatusCodes} from 'http-status-codes';
 import Optional from "../../../models/optional";
 import FormValidator from "../../../utils/common/form_validator";
 import change_email_address_schema from "../../../schemas/change_email_address_schema";
 import {RegisteredEmailAddress} from "@companieshouse/api-sdk-node/dist/services/registered-email-address/types";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import {CompanyProfile} from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 
 const PAGE_TITLE = "What is the new registered email address?";
 const EVENT = "change-email-address-event";
 
 export class ChangeEmailAddressHandler extends GenericHandler {
 
-  constructor (@inject(FormValidator) private validator: FormValidator, userEmail: string | undefined) {
+  constructor(@inject(FormValidator) private validator: FormValidator, userEmail: string | undefined) {
     super();
-    this.viewData.backUri = COMPANY_BASE_URL+CONFIRM_URL;
+    this.viewData.backUri = COMPANY_BASE_URL + CONFIRM_URL;
     if (userEmail !== undefined) {
       this.viewData.eventType = EVENT;
       this.viewData.title = PAGE_TITLE;
@@ -51,7 +54,7 @@ export class ChangeEmailAddressHandler extends GenericHandler {
     }
   }
 
-  async get (req: Request, response: Response): Promise<Object> {
+  async get(req: Request, response: Response): Promise<Object> {
     logger.info(`GET request to serve change registered email address page`);
 
     const session: Session = req.session as Session;
@@ -59,10 +62,19 @@ export class ChangeEmailAddressHandler extends GenericHandler {
     const companyEmailAddress: RegisteredEmailAddress | undefined = session.getExtraData(REGISTERED_EMAIL_ADDRESS);
     const companyProfile: CompanyProfile | undefined = session.getExtraData(COMPANY_PROFILE);
 
+    session.setExtraData(REGISTERED_EMAIL_ADDRESS_SUBMITTED, "false");
+
     if (companyEmailAddress && companyNumber && companyProfile) {
       this.viewData.companyEmailAddress = companyEmailAddress;
       this.viewData.companyName = companyProfile.companyName.toUpperCase();
       this.viewData.companyNumber = companyProfile.companyNumber;
+
+      const returnToConfirmationStatement: string = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT) as string;
+
+      if (returnToConfirmationStatement === "true") {
+        this.viewData.backUri = CONFIRMATION_STATEMENT_RETURN_URL;
+      }
+
       // create transaction record
       await createTransaction(session, companyNumber).then((transactionId) => {
         // get transaction record data
@@ -72,7 +84,7 @@ export class ChangeEmailAddressHandler extends GenericHandler {
         this.viewData.errors = formatValidationError(
           UPDATE_EMAIL_ERROR_KEY,
           UPDATE_EMAIL_ERROR_ANCHOR,
-          TRANSACTION_CREATE_ERROR+companyNumber
+          TRANSACTION_CREATE_ERROR + companyNumber
         );
         return Promise.reject(this.viewData);
       });
@@ -89,7 +101,7 @@ export class ChangeEmailAddressHandler extends GenericHandler {
     return Promise.resolve(this.viewData);
   }
 
-  async post (req: Request, response: Response): Promise<Object> {
+  async post(req: Request, response: Response): Promise<Object> {
     logger.info(`POST request to serve change registered email address page`);
 
     const session: Session = req.session as Session;
@@ -140,7 +152,7 @@ export const createTransaction = async (session: Session, companyNumber: string)
     });
     return Promise.resolve(transactionId);
   } catch (e) {
-    logger.error( `update registered email address: ${StatusCodes.INTERNAL_SERVER_ERROR} - error while create transaction record for ${companyNumber}`);
+    logger.error(`update registered email address: ${StatusCodes.INTERNAL_SERVER_ERROR} - error while create transaction record for ${companyNumber}`);
     return Promise.reject(`${StatusCodes.INTERNAL_SERVER_ERROR}`);
   }
 };

--- a/src/routers/handlers/email/change_email_address.ts
+++ b/src/routers/handlers/email/change_email_address.ts
@@ -10,6 +10,7 @@ import {formatValidationError} from "../../../utils/error/format_validation_erro
 import {
   COMPANY_NUMBER,
   COMPANY_PROFILE,
+  CONFIRMATION_STATEMENT_RETURN_URL,
   EMAIL_ADDRESS_INVALID,
   NEW_EMAIL_ADDRESS,
   NO_EMAIL_ADDRESS_FOUND,
@@ -25,7 +26,6 @@ import {
 import {
   COMPANY_BASE_URL,
   CONFIRM_URL,
-  CONFIRMATION_STATEMENT_RETURN_URL,
   DESCRIPTION,
   REFERENCE
 } from "../../../config";
@@ -62,17 +62,18 @@ export class ChangeEmailAddressHandler extends GenericHandler {
     const companyEmailAddress: RegisteredEmailAddress | undefined = session.getExtraData(REGISTERED_EMAIL_ADDRESS);
     const companyProfile: CompanyProfile | undefined = session.getExtraData(COMPANY_PROFILE);
 
-    session.setExtraData(REGISTERED_EMAIL_ADDRESS_SUBMITTED, "false");
+    session.setExtraData(REGISTERED_EMAIL_ADDRESS_SUBMITTED, false);
 
     if (companyEmailAddress && companyNumber && companyProfile) {
       this.viewData.companyEmailAddress = companyEmailAddress;
       this.viewData.companyName = companyProfile.companyName.toUpperCase();
       this.viewData.companyNumber = companyProfile.companyNumber;
 
-      const returnToConfirmationStatement: string = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT) as string;
+      const returnToConfirmationStatement: boolean = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT) as boolean;
+      const confirmationStatementReturnUrl: string = session.getExtraData(CONFIRMATION_STATEMENT_RETURN_URL) as string;
 
-      if (returnToConfirmationStatement === "true") {
-        this.viewData.backUri = CONFIRMATION_STATEMENT_RETURN_URL;
+      if (returnToConfirmationStatement === true && confirmationStatementReturnUrl) {
+        this.viewData.backUri = confirmationStatementReturnUrl;
       }
 
       // create transaction record

--- a/src/routers/handlers/email/update_submitted.ts
+++ b/src/routers/handlers/email/update_submitted.ts
@@ -1,13 +1,15 @@
-import { Request, Response } from "express";
-import { GenericHandler } from "../generic";
-import { logger } from "../../../utils/common/logger";
-import { Session } from "@companieshouse/node-session-handler";
+import {Request, Response} from "express";
+import {GenericHandler} from "../generic";
+import {logger} from "../../../utils/common/logger";
+import {Session} from "@companieshouse/node-session-handler";
 import {
-  COMPANY_PROFILE,
   COMPANY_NUMBER,
-  REGISTERED_EMAIL_ADDRESS,
-  NEW_EMAIL_ADDRESS,
+  COMPANY_PROFILE,
   INVALID_COMPANY_REASON,
+  NEW_EMAIL_ADDRESS,
+  REGISTERED_EMAIL_ADDRESS,
+  REGISTERED_EMAIL_ADDRESS_SUBMITTED,
+  RETURN_TO_CONFIRMATION_STATEMENT,
   SUBMISSION_ID
 } from "../../../constants/app_const";
 import {CONFIRMATION_FEEDBACK_LINK} from "../../../config";
@@ -17,19 +19,20 @@ const PAGE_TITLE = "Application submitted – Update a registered email address"
 
 export class UpdateSubmittedHandler extends GenericHandler {
 
-  constructor () {
+  constructor() {
     super();
     this.viewData.eventType = EVENT;
     this.viewData.title = PAGE_TITLE;
     this.viewData.feedback = CONFIRMATION_FEEDBACK_LINK;
   }
-  
-  async get (req: Request, response: Response): Promise<Object> {
+
+  async get(req: Request, response: Response): Promise<Object> {
     logger.info(`GET request to serve update submitted page`);
     const session: Session = req.session as Session;
     this.viewData.userEmail = session.data.signin_info?.user_profile?.email;
     this.viewData.backUri = undefined;
     this.viewData.submissionID = session.getExtraData(SUBMISSION_ID);
+    this.viewData.returnToConfirmationStatement = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT);
 
     // clear session.ExtraData
     session.setExtraData(COMPANY_PROFILE, undefined);
@@ -37,6 +40,18 @@ export class UpdateSubmittedHandler extends GenericHandler {
     session.setExtraData(REGISTERED_EMAIL_ADDRESS, undefined);
     session.setExtraData(NEW_EMAIL_ADDRESS, undefined);
     session.setExtraData(INVALID_COMPANY_REASON, undefined);
+
+    return Promise.resolve(this.viewData);
+  }
+
+  async post(req: Request, response: Response): Promise<any> {
+    logger.info(`POST return to confirmation statement`);
+    const session: Session = req.session as Session;
+    const returnToConfirmationStatement: string = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT) as string;
+
+    if (returnToConfirmationStatement === "true") {
+      session.setExtraData(REGISTERED_EMAIL_ADDRESS_SUBMITTED, "true");
+    }
 
     return Promise.resolve(this.viewData);
   }

--- a/src/routers/handlers/email/update_submitted.ts
+++ b/src/routers/handlers/email/update_submitted.ts
@@ -47,10 +47,10 @@ export class UpdateSubmittedHandler extends GenericHandler {
   async post(req: Request, response: Response): Promise<any> {
     logger.info(`POST return to confirmation statement`);
     const session: Session = req.session as Session;
-    const returnToConfirmationStatement: string = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT) as string;
+    const returnToConfirmationStatement: boolean = session.getExtraData(RETURN_TO_CONFIRMATION_STATEMENT) as boolean;
 
-    if (returnToConfirmationStatement === "true") {
-      session.setExtraData(REGISTERED_EMAIL_ADDRESS_SUBMITTED, "true");
+    if (returnToConfirmationStatement === true) {
+      session.setExtraData(REGISTERED_EMAIL_ADDRESS_SUBMITTED, true);
     }
 
     return Promise.resolve(this.viewData);

--- a/src/views/router-views/email/update-submitted.njk
+++ b/src/views/router-views/email/update-submitted.njk
@@ -30,7 +30,7 @@
         If you also need to change the email address you use to sign in to your Companies House account, you can do this in <a href="https://identity.company-information.service.gov.uk/user/account" class="govuk-link" data-event-id="your-details-link">'Your details'</a>. To change your WebFiling email address, log in to <a href="https://idam-ui.company-information.service.gov.uk/account/login/?realm=/alpha&amp;service=CHWebFiling-Login&amp;authIndexType=service&amp;authIndexValue=CHWebFiling-Login" class="govuk-link" data-event-id="web-filing-link">WebFiling</a> and go to 'Manage account'.
     </p>
 
-    {% if "true" === returnToConfirmationStatement %}
+    {% if true === returnToConfirmationStatement %}
         <form action="" method="post">
             {{ govukButton({
                 text: 'Return to Confirmation Statement',

--- a/src/views/router-views/email/update-submitted.njk
+++ b/src/views/router-views/email/update-submitted.njk
@@ -29,6 +29,19 @@
     <p>
         If you also need to change the email address you use to sign in to your Companies House account, you can do this in <a href="https://identity.company-information.service.gov.uk/user/account" class="govuk-link" data-event-id="your-details-link">'Your details'</a>. To change your WebFiling email address, log in to <a href="https://idam-ui.company-information.service.gov.uk/account/login/?realm=/alpha&amp;service=CHWebFiling-Login&amp;authIndexType=service&amp;authIndexValue=CHWebFiling-Login" class="govuk-link" data-event-id="web-filing-link">WebFiling</a> and go to 'Manage account'.
     </p>
+
+    {% if "true" === returnToConfirmationStatement %}
+        <form action="" method="post">
+            {{ govukButton({
+                text: 'Return to Confirmation Statement',
+                attributes: {
+                    id: 'submit',
+                    'data-event-id' : 'return-to-confirmation-statement'
+                }
+            }) }}
+        </form>
+    {% endif %}
+
     <p class="govuk-body">
         <a href={{feedback}} class="govuk-link" data-event-id="survey-link">What did you think of this service?</a> (takes 30 seconds)
     </p>

--- a/test/src/routers/email_router.unit.ts
+++ b/test/src/routers/email_router.unit.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import app from "../../../src/app";
 import {EMAIL_CHANGE_EMAIL_ADDRESS_URL, EMAIL_CHECK_ANSWER_URL, EMAIL_UPDATE_SUBMITTED_URL} from "../../../src/config";
 import {
+  CONFIRMATION_STATEMENT_RETURN_URL,
   CONFIRM_EMAIL_CHANGE_ERROR,
   FAILED_TO_CREATE_REA_ERROR,
   RETURN_TO_CONFIRMATION_STATEMENT
@@ -179,14 +180,16 @@ describe("Email router tests", () => {
 
     it("Should navigate back to Confirmation Statement service when originally called from it", async () => {
       const getSpy = jest.spyOn(UpdateSubmittedHandler.prototype, 'post').mockResolvedValue({title: "Application submitted"});
+      const CS_RETURN_URL_VALUE = "/confirmation-statement/active-submission-details-go-here/return-from-rea";
 
-      session.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+      session.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, true);
+      session.setExtraData(CONFIRMATION_STATEMENT_RETURN_URL, CS_RETURN_URL_VALUE);
 
       await request(app)
         .post(EMAIL_UPDATE_SUBMITTED_URL)
         .then((response) => {
           expect(response.status).toBe(StatusCodes.MOVED_TEMPORARILY);
-          expect(response.text).toContain("Found. Redirecting to /confirmation-statement/return-from-rea");
+          expect(response.text).toContain(`Found. Redirecting to ${CS_RETURN_URL_VALUE}`);
           expect(getSpy).toHaveBeenCalled();
           expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
         });

--- a/test/src/routers/email_router.unit.ts
+++ b/test/src/routers/email_router.unit.ts
@@ -1,20 +1,18 @@
 import mocks from "../../mocks/all_middleware_mock";
 import request from "supertest";
 import app from "../../../src/app";
-import {
-  EMAIL_CHANGE_EMAIL_ADDRESS_URL,
-  EMAIL_CHECK_ANSWER_URL,
-  EMAIL_UPDATE_SUBMITTED_URL
-} from "../../../src/config";
+import {EMAIL_CHANGE_EMAIL_ADDRESS_URL, EMAIL_CHECK_ANSWER_URL, EMAIL_UPDATE_SUBMITTED_URL} from "../../../src/config";
 import {
   CONFIRM_EMAIL_CHANGE_ERROR,
-  FAILED_TO_CREATE_REA_ERROR
+  FAILED_TO_CREATE_REA_ERROR,
+  RETURN_TO_CONFIRMATION_STATEMENT
 } from "../../../src/constants/app_const";
 import {HttpResponse} from "@companieshouse/api-sdk-node/dist/http/http-client";
 import {StatusCodes} from "http-status-codes";
 import {CheckAnswerHandler} from "../../../src/routers/handlers/email/check_answer";
 import {ChangeEmailAddressHandler} from "../../../src/routers/handlers/email/change_email_address";
 import {UpdateSubmittedHandler} from "../../../src/routers/handlers/email/update_submitted";
+import {session} from "../../mocks/session_middleware_mock";
 
 const okResponse: HttpResponse = {status: StatusCodes.OK};
 const movedTemporarilyResponse: HttpResponse = {status: StatusCodes.MOVED_TEMPORARILY};
@@ -96,7 +94,7 @@ describe("Email router tests", () => {
 
       it("Should navigate to confirm email page", async () => {
         const getSpy = jest.spyOn(CheckAnswerHandler.prototype, 'get')
-          .mockResolvedValue({title : "Check your answer before submitting this filing" });
+          .mockResolvedValue({title: "Check your answer before submitting this filing"});
 
         await request(app)
           .get(EMAIL_CHECK_ANSWER_URL)
@@ -118,7 +116,7 @@ describe("Email router tests", () => {
               text: "wrong deliberately"
             }]
           },
-          title : "Check your answer before submitting this filing"
+          title: "Check your answer before submitting this filing"
         };
         const postSpy = jest.spyOn(CheckAnswerHandler.prototype, 'post').mockRejectedValue(errorObject);
 
@@ -167,13 +165,28 @@ describe("Email router tests", () => {
     const PAGE_HEADING = "Application submitted – Update a registered email address";
 
     it("Should navigate to update submitted page", async () => {
-      const getSpy = jest.spyOn(UpdateSubmittedHandler.prototype, 'get').mockResolvedValue({title : "Application submitted"});
+      const getSpy = jest.spyOn(UpdateSubmittedHandler.prototype, 'get').mockResolvedValue({title: "Application submitted"});
 
       await request(app)
         .get(EMAIL_UPDATE_SUBMITTED_URL)
         .then((response) => {
           expect(response.status).toBe(StatusCodes.OK);
           expect(response.text).toContain(PAGE_HEADING);
+          expect(getSpy).toHaveBeenCalled();
+          expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        });
+    });
+
+    it("Should navigate back to Confirmation Statement service when originally called from it", async () => {
+      const getSpy = jest.spyOn(UpdateSubmittedHandler.prototype, 'post').mockResolvedValue({title: "Application submitted"});
+
+      session.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+
+      await request(app)
+        .post(EMAIL_UPDATE_SUBMITTED_URL)
+        .then((response) => {
+          expect(response.status).toBe(StatusCodes.MOVED_TEMPORARILY);
+          expect(response.text).toContain("Found. Redirecting to /confirmation-statement/return-from-rea");
           expect(getSpy).toHaveBeenCalled();
           expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
         });

--- a/test/src/routers/handlers/email/change_email_address.unit.ts
+++ b/test/src/routers/handlers/email/change_email_address.unit.ts
@@ -1,4 +1,3 @@
-import {CONFIRMATION_STATEMENT_RETURN_URL} from "../../../../../src/config";
 import "reflect-metadata";
 import {Request, Response} from "express";
 import {createRequest, createResponse, MockRequest, MockResponse} from 'node-mocks-http';
@@ -8,6 +7,7 @@ import {Session} from "@companieshouse/node-session-handler";
 import {
   COMPANY_NUMBER,
   COMPANY_PROFILE,
+  CONFIRMATION_STATEMENT_RETURN_URL,
   EMAIL_ADDRESS_INVALID,
   NO_EMAIL_ADDRESS_FOUND,
   NO_EMAIL_ADDRESS_SUPPLIED,
@@ -37,6 +37,7 @@ const CREATE_TRANSACTION_ERROR: string = TRANSACTION_CREATE_ERROR + COMPANY_NO;
 const INVALID_EMAIL_ADDRESS: string = "test-test.co.biz";
 const PROFILE = validCompanyProfile;
 const TEST_COMPANY_NAME: string = "TEST COMPANY";
+const CS_RETURN_URL_VALUE = "/confirmation-statement/active-submission-details-go-here/return-from-rea";
 
 // create form validator instance
 const formValidator = new FormValidator();
@@ -143,12 +144,13 @@ describe("Change email address - tests", () => {
       request.session?.setExtraData(REGISTERED_EMAIL_ADDRESS, TEST_EMAIL_EXISTING);
       request.session?.setExtraData(COMPANY_NUMBER, COMPANY_NO);
       request.session?.setExtraData(COMPANY_PROFILE, PROFILE);
-      request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+      request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, true);
+      request.session?.setExtraData(CONFIRMATION_STATEMENT_RETURN_URL, CS_RETURN_URL_VALUE);
 
       await changeEmailAddressHandler.get(request, response).then((changeEmailAddressResponse) => {
         const changeEmailAddressResponseJson = JSON.parse(JSON.stringify(changeEmailAddressResponse));
         expect(changeEmailAddressResponseJson.companyEmailAddress).toEqual(TEST_EMAIL_EXISTING);
-        expect(changeEmailAddressResponseJson.backUri).toEqual(CONFIRMATION_STATEMENT_RETURN_URL);
+        expect(changeEmailAddressResponseJson.backUri).toEqual(CS_RETURN_URL_VALUE);
         expect(changeEmailAddressResponseJson.userEmail).toEqual(TEST_EMAIL_EXISTING);
         expect(changeEmailAddressResponseJson.companyName).toEqual(TEST_COMPANY_NAME);
         expect(changeEmailAddressResponseJson.companyNumber).toEqual(COMPANY_NO);

--- a/test/src/routers/handlers/email/update_submitted.unit.ts
+++ b/test/src/routers/handlers/email/update_submitted.unit.ts
@@ -1,10 +1,10 @@
 import "reflect-metadata";
-import { Request, Response } from "express";
-import { createRequest, createResponse, MockRequest, MockResponse } from 'node-mocks-http';
-import { UpdateSubmittedHandler } from "../../../../../src/routers/handlers/email/update_submitted";
-import { Session } from "@companieshouse/node-session-handler";
-import { createSessionData } from "../../../../mocks/session_generator_mock";
-import { SUBMISSION_ID } from "../../../../../src/constants/app_const";
+import {Request, Response} from "express";
+import {createRequest, createResponse, MockRequest, MockResponse} from 'node-mocks-http';
+import {UpdateSubmittedHandler} from "../../../../../src/routers/handlers/email/update_submitted";
+import {Session} from "@companieshouse/node-session-handler";
+import {createSessionData} from "../../../../mocks/session_generator_mock";
+import {RETURN_TO_CONFIRMATION_STATEMENT, SUBMISSION_ID} from "../../../../../src/constants/app_const";
 import * as crypto from "crypto";
 
 const TEST_USER_EMAIL: string = "test_user@test.co.biz";
@@ -19,11 +19,11 @@ let session: Session;
 let request: MockRequest<Request>;
 const response: MockResponse<Response> = createResponse();
 
-describe("Registered email address update - test GET method", () => {  
-  it("Required submission data in object returned from handler", async () => {
+describe("Registered email address update - test GET method", () => {
+  it("Required submission data in object returned from handler - return to Confirmation Statement flag NOT set", async () => {
     // mock request/responses
     request = createRequest({
-      session: new Session({ 
+      session: new Session({
         ...createSessionData(cookieSecret)
       })
     });
@@ -36,8 +36,67 @@ describe("Registered email address update - test GET method", () => {
 
       expect(updateSubmittedResponseJson.userEmail).toEqual(TEST_USER_EMAIL);
       expect(updateSubmittedResponseJson.submissionID).toEqual(TEST_SUBMISSION_ID);
+      expect(updateSubmittedResponseJson.registeredEmailAddressSubmitted).toBeUndefined();
     });
   });
+
+  it("Required submission data in object returned from handler - return to Confirmation Statement flag set", async () => {
+    // mock request/responses
+    request = createRequest({
+      session: new Session({
+        ...createSessionData(cookieSecret)
+      })
+    });
+
+    // set submission id in session
+    request.session?.setExtraData(SUBMISSION_ID, TEST_SUBMISSION_ID);
+    request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+
+    await updateSubmittedHandler.get(request, response).then((updateSubmittedResponse) => {
+      const updateSubmittedResponseJson = JSON.parse(JSON.stringify(updateSubmittedResponse));
+
+      expect(updateSubmittedResponseJson.userEmail).toEqual(TEST_USER_EMAIL);
+      expect(updateSubmittedResponseJson.submissionID).toEqual(TEST_SUBMISSION_ID);
+      expect(updateSubmittedResponseJson.returnToConfirmationStatement).toEqual("true");
+    });
+  });
+
+  it("Registered Email Address submitted flag not set when REA service not called from Confirmation Statement service", async () => {
+    // mock request/responses
+    request = createRequest({
+      session: new Session({
+        ...createSessionData(cookieSecret)
+      })
+    });
+
+    // set submission id in session
+    request.session?.setExtraData(SUBMISSION_ID, TEST_SUBMISSION_ID);
+
+    await updateSubmittedHandler.post(request, response).then((updateSubmittedResponse) => {
+      const updateSubmittedResponseJson = JSON.parse(JSON.stringify(updateSubmittedResponse));
+
+      expect(updateSubmittedResponseJson.userEmail).toEqual(TEST_USER_EMAIL);
+      expect(updateSubmittedResponseJson.submissionID).toEqual(TEST_SUBMISSION_ID);
+      expect(updateSubmittedResponseJson.registeredEmailAddressSubmitted).toBeUndefined();
+    });
+  });
+
+  it("Registered Email Address submitted flag set correctly when REA service called from Confirmation Statement service", async () => {
+    // mock request/responses
+    request = createRequest({
+      session: new Session({
+        ...createSessionData(cookieSecret)
+      })
+    });
+
+    request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+
+    await updateSubmittedHandler.post(request, response).then((updateSubmittedResponse) => {
+      const registeredEmailAddressSubmitted: string | undefined = request.session?.getExtraData("registeredEmailAddressSubmitted");
+      expect(registeredEmailAddressSubmitted).toEqual("true");
+    });
+  });
+
 });
 
 export function generateRandomBytesBase64(numBytes: number): string {

--- a/test/src/routers/handlers/email/update_submitted.unit.ts
+++ b/test/src/routers/handlers/email/update_submitted.unit.ts
@@ -50,14 +50,14 @@ describe("Registered email address update - test GET method", () => {
 
     // set submission id in session
     request.session?.setExtraData(SUBMISSION_ID, TEST_SUBMISSION_ID);
-    request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+    request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, true);
 
     await updateSubmittedHandler.get(request, response).then((updateSubmittedResponse) => {
       const updateSubmittedResponseJson = JSON.parse(JSON.stringify(updateSubmittedResponse));
 
       expect(updateSubmittedResponseJson.userEmail).toEqual(TEST_USER_EMAIL);
       expect(updateSubmittedResponseJson.submissionID).toEqual(TEST_SUBMISSION_ID);
-      expect(updateSubmittedResponseJson.returnToConfirmationStatement).toEqual("true");
+      expect(updateSubmittedResponseJson.returnToConfirmationStatement).toEqual(true);
     });
   });
 
@@ -89,11 +89,11 @@ describe("Registered email address update - test GET method", () => {
       })
     });
 
-    request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, "true");
+    request.session?.setExtraData(RETURN_TO_CONFIRMATION_STATEMENT, true);
 
     await updateSubmittedHandler.post(request, response).then((updateSubmittedResponse) => {
       const registeredEmailAddressSubmitted: string | undefined = request.session?.getExtraData("registeredEmailAddressSubmitted");
-      expect(registeredEmailAddressSubmitted).toEqual("true");
+      expect(registeredEmailAddressSubmitted).toEqual(true);
     });
   });
 


### PR DESCRIPTION
Handles the case where the user has arrived on the change email address screen from the confirmation statement service.

Uses 2 new pieces of session data set by the confirmation statement service (boolean flag returnToConfirmationStatement & confirmationStatementReturnUrl) to determine onward behaviour for this scenario.

If returnToConfirmationStatement is true:
- the back button on the change email address screen takes the user back to the confirmation statement service
- after an rea is submitted, the update submitted page will contain a button labelled 'Return to Confirmation Statement', which takes the user back to the confirmation statement service

In both cases, the value passed in confirmationStatementReturnUrl is used to return to the confirmation statement service's handler within the correct submission context, and a new piece of session data (boolean flag registeredEmailAddressSubmitted) is set to indicate to the confirmation statement service whether the submission has been completed so that the appropriate page can be served.