### PR TITLE
Revert session timeout to 3600

### DIFF
--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -105,7 +105,7 @@ variable "api_url" {
 
 variable "session_timeout" {
   type    = string
-  default = "30"
+  default = "3600"
 }
 variable "session_countdown" {
   type    = string


### PR DESCRIPTION
CIDEV is showing unwanted timeout pop-ups - reverting session timeout var to value shown in README in an attempt to fix