### PR TITLE
feature/ecct-873 update email address statement for llp filing

### DIFF
--- a/src/routers/handlers/email/check_answer.ts
+++ b/src/routers/handlers/email/check_answer.ts
@@ -46,10 +46,10 @@ export class CheckAnswerHandler extends GenericHandler {
     this.viewData.companyName = companyProfile?.companyName.toUpperCase();
     this.viewData.companyNumber = companyProfile?.companyNumber;
 
-    this.viewData.statementText = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006.";
-
     if (companyProfile?.type === "llp") {
       this.viewData.statementText = "The new email address is an appropriate email address within the meaning given by section 2(5) of the Limited Liability Partnerships Act 2000.";
+    } else {
+      this.viewData.statementText = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006.";
     }
 
     return Promise.resolve(this.viewData);

--- a/src/routers/handlers/email/check_answer.ts
+++ b/src/routers/handlers/email/check_answer.ts
@@ -46,6 +46,12 @@ export class CheckAnswerHandler extends GenericHandler {
     this.viewData.companyName = companyProfile?.companyName.toUpperCase();
     this.viewData.companyNumber = companyProfile?.companyNumber;
 
+    this.viewData.statementText = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006.";
+
+    if (companyProfile?.type === "llp") {
+      this.viewData.statementText = "The new email address is an appropriate email address within the meaning given by section 2(5) of the Limited Liability Partnerships Act 2000.";
+    }
+
     return Promise.resolve(this.viewData);
   }
 

--- a/src/views/router-views/email/check-your-answer.njk
+++ b/src/views/router-views/email/check-your-answer.njk
@@ -35,7 +35,7 @@
             items: [
                 {
                     value: "true",
-                    text: "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006.",
+                    text: statementText,
                     attributes: {
                     'data-event-id': 'accepted-registered-email-address-statement'
                 }

--- a/test/mocks/company_profile_mock.ts
+++ b/test/mocks/company_profile_mock.ts
@@ -53,3 +53,43 @@ export const validSDKResource: Resource<CompanyProfile> = {
 export const CompanyProfileErrorResponse: ApiErrorResponse = {
   httpStatusCode: StatusCodes.INTERNAL_SERVER_ERROR
 };
+
+export const validLlpCompanyProfile: CompanyProfile = {
+  accounts: {
+    nextAccounts: {
+      periodEndOn: "2019-10-10",
+      periodStartOn: "2019-01-01",
+    },
+    nextDue: "2020-05-31",
+    overdue: false,
+  },
+  companyName: "Test Company",
+  companyNumber: "12345678",
+  companyStatus: "active",
+  companyStatusDetail: "company status detail",
+  confirmationStatement: {
+    lastMadeUpTo: "2019-04-30",
+    nextDue: "2020-04-30",
+    nextMadeUpTo: "2020-03-15",
+    overdue: false,
+  },
+  dateOfCreation: "1972-06-22",
+  hasBeenLiquidated: false,
+  hasCharges: false,
+  hasInsolvencyHistory: false,
+  jurisdiction: "england-wales",
+  links: {},
+  registeredOfficeAddress: {
+    addressLineOne: "Line1",
+    addressLineTwo: "Line2",
+    careOf: "careOf",
+    country: "uk",
+    locality: "locality",
+    poBox: "123",
+    postalCode: "POST CODE",
+    premises: "premises",
+    region: "region",
+  },
+  sicCodes: ["123"],
+  type: "llp",
+};

--- a/test/src/routers/handlers/email/check_answer.unit.ts
+++ b/test/src/routers/handlers/email/check_answer.unit.ts
@@ -33,7 +33,7 @@ const USER_EMAIL: string = "test_user@test.co.biz";
 const ID = "12345";
 const COMPANY_NUMBER = "12345678";
 const COMPANY_TYPE: string = "llp";
-const STATEMENT_TEXT: string = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006."
+const STATEMENT_TEXT: string = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006.";
 const LLP_STATEMENT_TEXT: string = "The new email address is an appropriate email address within the meaning given by section 2(5) of the Limited Liability Partnerships Act 2000.";
 const BACK_LINK_PATH: string = "/registered-email-address/email/change-email-address";
 const TITLE: string = "Error: Check your answer";
@@ -87,7 +87,7 @@ describe("Check answer - tests", () => {
         expect(dataJson.statementText).toEqual(STATEMENT_TEXT);
       });
     });
-/*
+    /*
     it("Should display the LLP Act Statement Text for an LLP company", async () => {
       request.session?.setExtraData(COMPANY_PROFILE, PROFILE);
       //how to change company type from ltd to llp?
@@ -100,7 +100,7 @@ describe("Check answer - tests", () => {
         //expect(dataJson.statementText).toEqual(LLP_STATEMENT_TEXT);
       });
     });
-*/
+    */
     describe("POST method tests", () => {
 
       it("Should reject incomplete data", async () => {

--- a/test/src/routers/handlers/email/check_answer.unit.ts
+++ b/test/src/routers/handlers/email/check_answer.unit.ts
@@ -9,10 +9,9 @@ import {
   COMPANY_PROFILE,
   CONFIRM_EMAIL_CHANGE_ERROR,
   NEW_EMAIL_ADDRESS,
-  NEW_COMPANY_TYPE,
   SUBMISSION_ID
 } from "../../../../../src/constants/app_const";
-import {validCompanyProfile} from "../../../../mocks/company_profile_mock";
+import {validCompanyProfile, validLlpCompanyProfile} from "../../../../mocks/company_profile_mock";
 import {createSessionData} from "../../../../mocks/session_generator_mock";
 import {generateRandomBytesBase64} from "./update_submitted.unit";
 import {closeTransaction} from "../../../../../src/services/transaction/transaction_service";
@@ -21,18 +20,17 @@ import {
 } from "@companieshouse/api-sdk-node/dist/services/registered-email-address/types";
 import {StatusCodes} from "http-status-codes";
 import {ApiResponse} from "@companieshouse/api-sdk-node/dist/services/resource";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 
 jest.mock("../../../../../src/services/email/email_registered_service");
 jest.mock("../../../../../src/services/transaction/transaction_service");
 
 const PROFILE = validCompanyProfile;
+const LLP_PROFILE = validLlpCompanyProfile;
 const EMAIL_ADDRESS: string = "test@test.com";
 const COMPANY_NAME: string = "TEST COMPANY";
 const USER_EMAIL: string = "test_user@test.co.biz";
 const ID = "12345";
 const COMPANY_NUMBER = "12345678";
-const COMPANY_TYPE: string = "llp";
 const STATEMENT_TEXT: string = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006.";
 const LLP_STATEMENT_TEXT: string = "The new email address is an appropriate email address within the meaning given by section 2(5) of the Limited Liability Partnerships Act 2000.";
 const BACK_LINK_PATH: string = "/registered-email-address/email/change-email-address";
@@ -87,20 +85,16 @@ describe("Check answer - tests", () => {
         expect(dataJson.statementText).toEqual(STATEMENT_TEXT);
       });
     });
-    /*
+    
     it("Should display the LLP Act Statement Text for an LLP company", async () => {
-      request.session?.setExtraData(COMPANY_PROFILE, PROFILE);
-      //how to change company type from ltd to llp?
-      //request.session?.setExtraData(NEW_COMPANY_TYPE, COMPANY_TYPE);
-      request.body.type = COMPANY_TYPE;
+      request.session?.setExtraData(COMPANY_PROFILE, LLP_PROFILE);
 
       await checkAnswerHandler.get(request, response).then((data) => {
         const dataJson = JSON.parse(JSON.stringify(data));
-        expect(dataJson.type).toEqual(COMPANY_TYPE);
-        //expect(dataJson.statementText).toEqual(LLP_STATEMENT_TEXT);
+        expect(dataJson.statementText).toEqual(LLP_STATEMENT_TEXT);
       });
     });
-    */
+    
     describe("POST method tests", () => {
 
       it("Should reject incomplete data", async () => {

--- a/test/src/routers/handlers/email/check_answer.unit.ts
+++ b/test/src/routers/handlers/email/check_answer.unit.ts
@@ -9,6 +9,7 @@ import {
   COMPANY_PROFILE,
   CONFIRM_EMAIL_CHANGE_ERROR,
   NEW_EMAIL_ADDRESS,
+  NEW_COMPANY_TYPE,
   SUBMISSION_ID
 } from "../../../../../src/constants/app_const";
 import {validCompanyProfile} from "../../../../mocks/company_profile_mock";
@@ -20,6 +21,7 @@ import {
 } from "@companieshouse/api-sdk-node/dist/services/registered-email-address/types";
 import {StatusCodes} from "http-status-codes";
 import {ApiResponse} from "@companieshouse/api-sdk-node/dist/services/resource";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 
 jest.mock("../../../../../src/services/email/email_registered_service");
 jest.mock("../../../../../src/services/transaction/transaction_service");
@@ -30,6 +32,9 @@ const COMPANY_NAME: string = "TEST COMPANY";
 const USER_EMAIL: string = "test_user@test.co.biz";
 const ID = "12345";
 const COMPANY_NUMBER = "12345678";
+const COMPANY_TYPE: string = "llp";
+const STATEMENT_TEXT: string = "The new email address is an appropriate email address as outlined in section 88A(2) of the Companies Act 2006."
+const LLP_STATEMENT_TEXT: string = "The new email address is an appropriate email address within the meaning given by section 2(5) of the Limited Liability Partnerships Act 2000.";
 const BACK_LINK_PATH: string = "/registered-email-address/email/change-email-address";
 const TITLE: string = "Error: Check your answer";
 const TRANSACTION_ID = "178417-909116-690426";
@@ -76,6 +81,26 @@ describe("Check answer - tests", () => {
       });
     });
 
+    it("Should display the Companies Act Statement Text by default", async () => {
+      await checkAnswerHandler.get(request, response).then((data) => {
+        const dataJson = JSON.parse(JSON.stringify(data));
+        expect(dataJson.statementText).toEqual(STATEMENT_TEXT);
+      });
+    });
+/*
+    it("Should display the LLP Act Statement Text for an LLP company", async () => {
+      request.session?.setExtraData(COMPANY_PROFILE, PROFILE);
+      //how to change company type from ltd to llp?
+      //request.session?.setExtraData(NEW_COMPANY_TYPE, COMPANY_TYPE);
+      request.body.type = COMPANY_TYPE;
+
+      await checkAnswerHandler.get(request, response).then((data) => {
+        const dataJson = JSON.parse(JSON.stringify(data));
+        expect(dataJson.type).toEqual(COMPANY_TYPE);
+        //expect(dataJson.statementText).toEqual(LLP_STATEMENT_TEXT);
+      });
+    });
+*/
     describe("POST method tests", () => {
 
       it("Should reject incomplete data", async () => {


### PR DESCRIPTION
__Jira Number:__ [ECCT-873](https://companieshouse.atlassian.net/browse/ECCT-873)

__Short Description:__
- Created a conditional which changes the statement text depending on the company type that is using the registered email address update service. 
    - LLP company type will be shown the statement text referencing the LLP act, 
    - while other company types will be shown the statement text referencing the companies act.
- Unit tests were added to check functionality is working as expected.

[ECCT-873]: https://companieshouse.atlassian.net/browse/ECCT-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ