### PR TITLE
Bump version of web-security-node which fixes the regression observed in ci-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@companieshouse/api-sdk-node": "^2.0.147",
         "@companieshouse/node-session-handler": "^5.0.1",
         "@companieshouse/structured-logging-node": "^2.0.1",
-        "@companieshouse/web-security-node": "^4.3.1",
+        "@companieshouse/web-security-node": "^4.4.0",
         "aws-sdk": "^2.1392.0",
         "axios": "1.6.5",
         "cookie-parser": "1.4.5",
@@ -828,9 +828,9 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.3.1.tgz",
-      "integrity": "sha512-sQhbApcY5a5K8eSHdnPDiyY5q4DiMF/j6Q3tsaHx4yJs5264JDk3aFcPr0ZhcePBB7kVnekGg1idvPdN0TZcvQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.0.tgz",
+      "integrity": "sha512-JF7Oi+ljrVLhpkGgQdN4tV58IDw1Vn41wtYJxD+QkyVq5Ll+/W8RtcCR8Sdc2ugiDqd3DpxqGWyt9fhIRz4iyQ==",
       "dependencies": {
         "@companieshouse/node-session-handler": "~5.1.3",
         "@companieshouse/structured-logging-node": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@companieshouse/api-sdk-node": "^2.0.147",
     "@companieshouse/node-session-handler": "^5.0.1",
     "@companieshouse/structured-logging-node": "^2.0.1",
-    "@companieshouse/web-security-node": "^4.3.1",
+    "@companieshouse/web-security-node": "^4.4.0",
     "aws-sdk": "^2.1392.0",
     "axios": "1.6.5",
     "cookie-parser": "1.4.5",


### PR DESCRIPTION
* Prior version of web-security-node would not handle case when Cookie not set (i.e. new unauthenticated request) this was fixed in [companiehouse/web-security-node#95](https://github.com/companieshouse/web-security-node/pull/95) (4.4.0)
