### PR TITLE
Add EnsureSessionCookiePresentMiddleware to app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@companieshouse/api-sdk-node": "^2.0.147",
-        "@companieshouse/node-session-handler": "^5.0.1",
+        "@companieshouse/node-session-handler": "^5.2.0",
         "@companieshouse/structured-logging-node": "^2.0.1",
         "@companieshouse/web-security-node": "^4.4.0",
         "aws-sdk": "^2.1392.0",
@@ -757,9 +757,9 @@
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.1.4.tgz",
-      "integrity": "sha512-giKQWlnaugFcgQoHrBMN61x6GMLrwcxkPS1y0NnMpXLePynQKbkdXjUm4aoWSS4fNe95tg2YnJkU66XWjnwhKw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.0.tgz",
+      "integrity": "sha512-9ihSGNwx/chZlaHxy5eCKdI6V7I7kNIRhpy9O6ZjE+5jkhfn0qArUdtGnzl7AhknS4OWGGOTiinuV0ZTbO0tjQ==",
       "dependencies": {
         "@companieshouse/structured-logging-node": "^1.0.0",
         "crypto": "^1.0.1",
@@ -837,6 +837,67 @@
         "express-async-handler": "^1.2.0",
         "uuid": "^9.0.1"
       }
+    },
+    "node_modules/@companieshouse/web-security-node/node_modules/@companieshouse/node-session-handler": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.1.4.tgz",
+      "integrity": "sha512-giKQWlnaugFcgQoHrBMN61x6GMLrwcxkPS1y0NnMpXLePynQKbkdXjUm4aoWSS4fNe95tg2YnJkU66XWjnwhKw==",
+      "dependencies": {
+        "@companieshouse/structured-logging-node": "^1.0.0",
+        "crypto": "^1.0.1",
+        "express-async-handler": "^1.1.4",
+        "ioredis": "^4.17.3",
+        "msgpack5": "^4.5.1",
+        "on-headers": "^1.0.2"
+      }
+    },
+    "node_modules/@companieshouse/web-security-node/node_modules/@companieshouse/node-session-handler/node_modules/@companieshouse/structured-logging-node": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@companieshouse/structured-logging-node/-/structured-logging-node-1.0.8.tgz",
+      "integrity": "sha512-mCCsrP1ObzV4TUOdn8gCiGcvTGZ8XYQUs6ECRHiN9Gj5wekLGquSCc82ZMFuAxbBZ13vYgb8NhCxINcJIeoPug==",
+      "dependencies": {
+        "moment": "^2.29.4",
+        "on-finished": "~2.3.0",
+        "winston": "~3.3.3"
+      }
+    },
+    "node_modules/@companieshouse/web-security-node/node_modules/ioredis": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+      "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+      "dependencies": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/@companieshouse/web-security-node/node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@companieshouse/web-security-node/node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "node_modules/@companieshouse/web-security-node/node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@companieshouse/api-sdk-node": "^2.0.147",
-    "@companieshouse/node-session-handler": "^5.0.1",
+    "@companieshouse/node-session-handler": "^5.2.0",
     "@companieshouse/structured-logging-node": "^2.0.1",
     "@companieshouse/web-security-node": "^4.4.0",
     "aws-sdk": "^2.1392.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import {authentication_middleware} from "./middleware/authentication_middleware"
 import {company_authentication_middleware} from "./middleware/company_authentication_middleware";
 import cookieParser from "cookie-parser";
 import {pageNotFound} from "./utils/error/error";
-import { createSessionMiddleware } from "./middleware/session_middleware";
+import { createEnsureSessionCookieSetMiddleware, createSessionMiddleware } from "./middleware/session_middleware";
 import { SessionStore } from "@companieshouse/node-session-handler";
 import Redis from "ioredis";
 import { CACHE_SERVER, COOKIE_DOMAIN, COOKIE_NAME, COOKIE_SECRET, DEFAULT_SESSION_EXPIRATION } from "./config";
@@ -35,6 +35,7 @@ const redis = new Redis(CACHE_SERVER);
 const sessionStore = new SessionStore(redis);
 
 const sessionMiddleware = createSessionMiddleware(sessionStore);
+const ensureSessionCookiePresentMiddleware = createEnsureSessionCookieSetMiddleware();
 const csrfProtectionMiddleware = createCsrfProtectionMiddleware(sessionStore);
 
 app.set("views", [
@@ -98,6 +99,7 @@ process.on("unhandledRejection", (err: any) => {
 // Apply middleware
 app.use(cookieParser());
 app.use(sessionMiddleware);
+app.use(ensureSessionCookiePresentMiddleware);
 
 app.use(csrfProtectionMiddleware);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -98,8 +98,12 @@ process.on("unhandledRejection", (err: any) => {
 
 // Apply middleware
 app.use(cookieParser());
+
 app.use(sessionMiddleware);
-app.use(ensureSessionCookiePresentMiddleware);
+
+// Scope to the application routes rather than all routes to not put on
+// healthcheck route since could cause application to become unhealthy
+app.use(`${HOME_URL}*`, ensureSessionCookiePresentMiddleware);
 
 app.use(csrfProtectionMiddleware);
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -61,6 +61,7 @@ export const THERE_IS_A_PROBLEM_PAGE = "there-is-a-problem";
 
 
 // ROUTING PATHS
+export const HEALTHCHECK_URL = "/healthcheck";
 export const HOME_URL = `${REA_HOME_PAGE}`;
 export const COMPANY_BASE_URL = `${REA_HOME_PAGE}/company`;
 export const EMAIL_BASE_URL = `${REA_HOME_PAGE}/email`;

--- a/src/middleware/csrf_middleware.ts
+++ b/src/middleware/csrf_middleware.ts
@@ -23,6 +23,7 @@ export const csrfErrorHandler = (
 
 export const createCsrfProtectionMiddleware = (sessionStore: SessionStore) => 
   CsrfProtectionMiddleware({
+    // @ts-expect-error  Looks like there is a minor version disparity somewhere along but nothing too significant
     sessionStore: sessionStore,
     enabled: true,
     sessionCookieName: COOKIE_NAME

--- a/src/middleware/session_middleware.ts
+++ b/src/middleware/session_middleware.ts
@@ -1,10 +1,18 @@
-import { SessionMiddleware, SessionStore } from "@companieshouse/node-session-handler";
-import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_SECRET, DEFAULT_SESSION_EXPIRATION } from "../config";
+import { EnsureSessionCookiePresentMiddleware, SessionMiddleware, SessionStore } from "@companieshouse/node-session-handler";
+import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_SECRET, DEFAULT_SESSION_EXPIRATION, NODE_ENV } from "../config";
+
+const environmentsWithInsecureCookies = [
+  "local"
+];
 
 export const createSessionMiddleware = (sessionStore: SessionStore) => SessionMiddleware({
   cookieDomain: COOKIE_DOMAIN,
   cookieName: COOKIE_NAME,
   cookieSecret: COOKIE_SECRET,
-  cookieSecureFlag: undefined,
+  cookieSecureFlag: NODE_ENV !== undefined && !environmentsWithInsecureCookies.includes(NODE_ENV),
   cookieTimeToLiveInSeconds: parseInt(DEFAULT_SESSION_EXPIRATION, 10),
 }, sessionStore, true);
+
+export const createEnsureSessionCookieSetMiddleware = () => EnsureSessionCookiePresentMiddleware({
+  cookieName: COOKIE_NAME
+});

--- a/src/router_dispatch.ts
+++ b/src/router_dispatch.ts
@@ -4,8 +4,10 @@ import * as config from "./config/index";
 import index_router from "./routers/index_router";
 import company_router from "./routers/company_router";
 import email_router from "./routers/email_router";
+import healthcheck from "./routers/healthcheck";
 
 const router_dispatch = (app: Application) => {
+  app.use(config.HEALTHCHECK_URL, healthcheck);
   app.use("/", index_router);
   app.use(config.COMPANY_BASE_URL, company_router);
   app.use(config.EMAIL_BASE_URL, email_router);

--- a/src/routers/healthcheck.ts
+++ b/src/routers/healthcheck.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from "express";
+
+const healthcheck = (req: Request, res: Response, next: NextFunction) => {
+  res.status(200).send("OK");
+};
+
+export default healthcheck;

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -9,11 +9,9 @@ locals {
   kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority = 39
   lb_listener_paths         = ["/registered-email-address*"]
-  healthcheck_path          = "/registered-email-address" #healthcheck path for registered-email-address web
+  healthcheck_path          = "/healthcheck" #healthcheck path for registered-email-address web
 
-  # May be a redirect request if the initial request does not have a session cookie attached to it
-  # therefore a 302/redirection is an acceptable response
-  healthcheck_matcher         = "200,302"
+  healthcheck_matcher         = "200"
   vpc_name                    = local.stack_secrets["vpc_name"]
   s3_config_bucket            = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
   app_environment_filename    = "registered-email-address-web.env"

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -10,7 +10,10 @@ locals {
   lb_listener_rule_priority = 39
   lb_listener_paths         = ["/registered-email-address*"]
   healthcheck_path          = "/registered-email-address" #healthcheck path for registered-email-address web
-  healthcheck_matcher         = "200"
+
+  # May be a redirect request if the initial request does not have a session cookie attached to it
+  # therefore a 302/redirection is an acceptable response
+  healthcheck_matcher         = "200,302"
   vpc_name                    = local.stack_secrets["vpc_name"]
   s3_config_bucket            = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
   app_environment_filename    = "registered-email-address-web.env"

--- a/test/mocks/session_middleware_mock.ts
+++ b/test/mocks/session_middleware_mock.ts
@@ -4,13 +4,15 @@ jest.mock("ioredis");
 jest.mock("../../src/middleware/session_middleware");
 
 import { NextFunction, Request, Response } from "express";
-import { createSessionMiddleware } from "../../src/middleware/session_middleware";
+import { createSessionMiddleware, createEnsureSessionCookieSetMiddleware } from "../../src/middleware/session_middleware";
 import { Session } from "@companieshouse/node-session-handler";
 import {REGISTERED_EMAIL_ADDRESS, COMPANY_NUMBER, RETURN_URL, COMPANY_PROFILE} from "../../src/constants/app_const";
 
 // get handle on mocked function
 const mockCreateSessionMiddleware = createSessionMiddleware as jest.Mock;
+const mockCreateEnsureSessionCookieSetMiddleware = createEnsureSessionCookieSetMiddleware as jest.Mock;
 const mockSessionMiddleware = jest.fn();
+const mockEnsureSessionCookieSetMiddleware = jest.fn()
 
 export const session = new Session();
 const NUMBER = "1234567";
@@ -20,6 +22,7 @@ const PROFILE = validCompanyProfile;
 
 // tell the middleware factory to return a mock
 mockCreateSessionMiddleware.mockReturnValue(mockSessionMiddleware);
+mockCreateEnsureSessionCookieSetMiddleware.mockReturnValue(mockEnsureSessionCookieSetMiddleware);
 
 // tell the mock what to return
 mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
@@ -30,5 +33,9 @@ mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: Nex
   req.session.data.extra_data[COMPANY_PROFILE] = PROFILE;
   next();
 });
+
+mockEnsureSessionCookieSetMiddleware.mockImplementation((_, __, next) => {
+  next();
+})
 
 export default mockSessionMiddleware;


### PR DESCRIPTION
* To fix the regression whereby the request requires a CSRF error, the EnsureSessionCookiePresentMiddleware will ensure the request hitting the CSRF middleware has a session cookie attached to it and redirects if not
* Minor suppression given a mismatch somewhere of the typescript types for ioredis
* Create healthcheck endpoint to bypass the redirection logic
* Update ECS healthcheck to use separate healthcheck endpoint
* In non-AWS environments there may not be https so set the insecure property correctly
