### PR TITLE
remove dead link

### DIFF
--- a/src/views/router-views/index/accessibility-statement.njk
+++ b/src/views/router-views/index/accessibility-statement.njk
@@ -9,7 +9,6 @@
         <li><a href="#item-2" class="govuk-link">Reporting accessibility problems with this service</a></li>
         <li><a href="#item-3" class="govuk-link">Enforcement procedure</a></li>
         <li><a href="#item-4" class="govuk-link">Technical information about this service’s accessibility</a></li>
-        <li><a href="#item-5" class="govuk-link">Non-accessible content</a></li>
         <li><a href="#item-6" class="govuk-link">What we’re doing to improve accessibility</a></li>
         <li><a href="#item-7" class="govuk-link">Preparation of this accessibility statement</a></li>
       </ul>


### PR DESCRIPTION
- Remove "non-accessible content" link as the section it links to has been removed.