### PR TITLE
chore/cc-2201: remove reference to v18 engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,8 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": "^8"
+        "node": ">=20.0.0",
+        "npm": "^10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Web front-end for Registered Email Address Service",
   "main": "dist/server.js",
   "engines": {
-    "node": ">=18.0.0",
-    "npm": "^8"
+    "node": ">=20.0.0",
+    "npm": "^10"
   },
   "scripts": {
     "prebuild": "rm -rf ./dist",


### PR DESCRIPTION
Removes reference to v18 engine (or earlier) in `package.json`