### PR TITLE
fix(FS-406): run npm audit to fix high severity vulnerability in form-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -674,16 +674,16 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "4.4.20",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.20.tgz",
-      "integrity": "sha512-x5xMuURVC33Fd1Q0JW9lcZM6ovMUeh2X+m5NlgStLUEslhX4pOi58QKr636B9z+Lb2mWg2Y6xWMUZlQ/2WEkRg==",
+      "version": "4.4.21",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.21.tgz",
+      "integrity": "sha512-52sut3LL3d23XiJB6GqbuuW5KM8sUU1WihA0efoHCxnk+keGnaQH1hz3IC58MvHV3IRfZWs7lWPbwlQP4d2aiA==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "~5.2.14",
         "@companieshouse/structured-logging-node": "~2.0.13",
         "crypto": "^1.0.1",
         "express-async-handler": "^1.2.0",
-        "uuid": "^14.0.0"
+        "uuid": "^11.0.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -7095,16 +7095,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"


### PR DESCRIPTION
## Description

Before beginning work on adding prettier to the repo, `npm audit` detected a high severity security vulnerability in the `form-data` package.

This PR commits an updated `package-lock.json` produced from running `npm audit fix` to resolve the high severity security vulnerability.

## Jira Ticket

Jira ticket ID: [FS-406](https://companieshouse.atlassian.net/browse/FS-406)

[FS-406]: https://companieshouse.atlassian.net/browse/FS-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ